### PR TITLE
Add Standard C# Implementation for DopeGrid

### DIFF
--- a/Assets/Tests/Native/GridBoardExtensionTests.cs
+++ b/Assets/Tests/Native/GridBoardExtensionTests.cs
@@ -1,3 +1,4 @@
+using DopeGrid;
 using DopeGrid.Native;
 using NUnit.Framework;
 using Unity.Collections;
@@ -20,8 +21,8 @@ public class GridBoardExtensionTests
 
         var position = inventory.FindFirstFit(item);
 
-        Assert.AreEqual(2, position.x);
-        Assert.AreEqual(0, position.y);
+        Assert.AreEqual(2, position.X);
+        Assert.AreEqual(0, position.Y);
 
         inventory.Dispose();
         item.Dispose();
@@ -40,8 +41,8 @@ public class GridBoardExtensionTests
 
         var position = inventory.FindFirstFit(item);
 
-        Assert.AreEqual(-1, position.x);
-        Assert.AreEqual(-1, position.y);
+        Assert.AreEqual(-1, position.X);
+        Assert.AreEqual(-1, position.Y);
 
         inventory.Dispose();
         item.Dispose();
@@ -120,7 +121,7 @@ public class GridBoardExtensionTests
         var inventory = new GridShape(10, 10, Allocator.Temp);
 
         var items = new NativeArray<GridShape>(3, Allocator.Temp);
-        var positions = new NativeArray<int2>(3, Allocator.Temp);
+        var positions = new NativeArray<GridPosition>(3, Allocator.Temp);
 
         for (var i = 0; i < 3; i++)
         {

--- a/Assets/Tests/Native/ImmutableGridShapeTests.cs
+++ b/Assets/Tests/Native/ImmutableGridShapeTests.cs
@@ -12,7 +12,7 @@ public class ImmutableGridShapeTests
         var empty = ImmutableGridShape.Empty;
 
         Assert.AreEqual(0, empty.Id);
-        Assert.AreEqual(int2.zero, empty.Bound);
+        Assert.AreEqual((0, 0), empty.Bound);
         Assert.AreEqual(0, empty.Width);
         Assert.AreEqual(0, empty.Height);
     }

--- a/Assets/Tests/Native/ValueGridShapeTests.cs
+++ b/Assets/Tests/Native/ValueGridShapeTests.cs
@@ -212,7 +212,7 @@ public class ValueGridShapeTests
     {
         var grid = new ValueGridShape<int>(4, 4, Allocator.Temp);
 
-        grid.FillRect(new int2(1, 1), new int2(2, 2), 55);
+        grid.FillRect(1, 1, 2, 2, 55);
 
         Assert.AreEqual(55, grid[1, 1]);
         Assert.AreEqual(55, grid[2, 1]);

--- a/Assets/Tests/Standard.meta
+++ b/Assets/Tests/Standard.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 785f4e1fe6bb54e3380b66f3c91946f2
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Standard/GridBoardExtensionTests.cs
+++ b/Assets/Tests/Standard/GridBoardExtensionTests.cs
@@ -12,7 +12,7 @@ public class StandardGridBoardExtensionTests
 
         var pos = container.FindFirstFit(item.AsReadOnly());
 
-        Assert.AreEqual((0, 0), pos);
+        Assert.AreEqual(GridPosition.Zero, pos);
     }
 
     [Test]
@@ -37,7 +37,7 @@ public class StandardGridBoardExtensionTests
         using var item = Shapes.Single();
         var pos = container.FindFirstFit(item.AsReadOnly());
 
-        Assert.AreEqual((-1, -1), pos);
+        Assert.AreEqual(new GridPosition(-1, -1), pos);
     }
 
     [Test]
@@ -48,7 +48,7 @@ public class StandardGridBoardExtensionTests
 
         var pos = container.FindFirstFit(item.AsReadOnly());
 
-        Assert.AreEqual((-1, -1), pos);
+        Assert.AreEqual(new GridPosition(-1, -1), pos);
     }
 
     [Test]

--- a/Assets/Tests/Standard/GridBoardExtensionTests.cs
+++ b/Assets/Tests/Standard/GridBoardExtensionTests.cs
@@ -1,0 +1,234 @@
+using DopeGrid.Standard;
+using NUnit.Framework;
+
+public class StandardGridBoardExtensionTests
+{
+    [Test]
+    public void FindFirstFit_FindsCorrectPosition()
+    {
+        using var container = new GridShape(5, 5);
+        using var item = Shapes.Square(2);
+
+        var pos = container.FindFirstFit(item.AsReadOnly());
+
+        Assert.AreEqual((0, 0), pos);
+    }
+
+    [Test]
+    public void FindFirstFit_SkipsOccupiedAreas()
+    {
+        using var container = new GridShape(5, 5);
+        container.FillRect(0, 0, 2, 2, true);
+
+        using var item = Shapes.Square(2);
+        var pos = container.FindFirstFit(item.AsReadOnly());
+
+        Assert.AreNotEqual((0, 0), pos);
+        Assert.IsTrue(pos.x >= 0 && pos.y >= 0);
+    }
+
+    [Test]
+    public void FindFirstFit_ReturnsNegativeWhenNoFit()
+    {
+        using var container = new GridShape(2, 2);
+        container.Fill(true);
+
+        using var item = Shapes.Single();
+        var pos = container.FindFirstFit(item.AsReadOnly());
+
+        Assert.AreEqual((-1, -1), pos);
+    }
+
+    [Test]
+    public void FindFirstFit_ItemTooLarge_ReturnsNegative()
+    {
+        using var container = new GridShape(3, 3);
+        using var item = Shapes.Square(5);
+
+        var pos = container.FindFirstFit(item.AsReadOnly());
+
+        Assert.AreEqual((-1, -1), pos);
+    }
+
+    [Test]
+    public void CanPlaceItem_ReturnsTrueForValidPosition()
+    {
+        using var container = new GridShape(5, 5);
+        using var item = Shapes.Square(2);
+
+        Assert.IsTrue(container.CanPlaceItem(item.AsReadOnly(), (1, 1)));
+        Assert.IsTrue(container.CanPlaceItem(item.AsReadOnly(), (0, 0)));
+        Assert.IsTrue(container.CanPlaceItem(item.AsReadOnly(), (3, 3)));
+    }
+
+    [Test]
+    public void CanPlaceItem_ReturnsFalseForOutOfBounds()
+    {
+        using var container = new GridShape(5, 5);
+        using var item = Shapes.Square(2);
+
+        Assert.IsFalse(container.CanPlaceItem(item.AsReadOnly(), (4, 4)));
+        Assert.IsFalse(container.CanPlaceItem(item.AsReadOnly(), (5, 0)));
+        Assert.IsFalse(container.CanPlaceItem(item.AsReadOnly(), (-1, 0)));
+    }
+
+    [Test]
+    public void CanPlaceItem_ReturnsFalseForOccupiedSpace()
+    {
+        using var container = new GridShape(5, 5);
+        container.SetCell((2, 2), true);
+
+        using var item = Shapes.Square(2);
+
+        Assert.IsFalse(container.CanPlaceItem(item.AsReadOnly(), (1, 1)));
+        Assert.IsTrue(container.CanPlaceItem(item.AsReadOnly(), (3, 3)));
+    }
+
+    [Test]
+    public void PlaceItem_PlacesItemCorrectly()
+    {
+        using var container = new GridShape(5, 5);
+        using var item = Shapes.LShape();
+
+        container.PlaceItem(item.AsReadOnly(), (1, 1));
+
+        Assert.IsTrue(container.GetCell((1, 1)));
+        Assert.IsTrue(container.GetCell((1, 2)));
+        Assert.IsTrue(container.GetCell((2, 2)));
+        Assert.IsFalse(container.GetCell((2, 1)));
+        Assert.IsFalse(container.GetCell((0, 0)));
+    }
+
+    [Test]
+    public void PlaceItem_OnlyPlacesShapeCells()
+    {
+        using var container = new GridShape(5, 5);
+        using var item = Shapes.LShape();
+
+        container.PlaceItem(item.AsReadOnly(), (2, 2));
+
+        // L-shape at (2,2): (2,2), (2,3), (3,3)
+        Assert.IsTrue(container.GetCell((2, 2)));
+        Assert.IsTrue(container.GetCell((2, 3)));
+        Assert.IsTrue(container.GetCell((3, 3)));
+        Assert.IsFalse(container.GetCell((3, 2)));
+    }
+
+    [Test]
+    public void RemoveItem_RemovesItemCorrectly()
+    {
+        using var container = new GridShape(5, 5);
+        using var item = Shapes.Square(2);
+
+        container.PlaceItem(item.AsReadOnly(), (1, 1));
+        container.RemoveItem(item.AsReadOnly(), (1, 1));
+
+        Assert.IsFalse(container.GetCell((1, 1)));
+        Assert.IsFalse(container.GetCell((2, 1)));
+        Assert.IsFalse(container.GetCell((1, 2)));
+        Assert.IsFalse(container.GetCell((2, 2)));
+    }
+
+    [Test]
+    public void RemoveItem_OnlyRemovesShapeCells()
+    {
+        using var container = new GridShape(5, 5);
+        container.Fill(true);
+
+        using var item = Shapes.LShape();
+
+        container.RemoveItem(item.AsReadOnly(), (2, 2));
+
+        // L-shape cells should be removed
+        Assert.IsFalse(container.GetCell((2, 2)));
+        Assert.IsFalse(container.GetCell((2, 3)));
+        Assert.IsFalse(container.GetCell((3, 3)));
+        // Other cells should remain
+        Assert.IsTrue(container.GetCell((3, 2)));
+        Assert.IsTrue(container.GetCell((0, 0)));
+    }
+
+    [Test]
+    public void PlaceMultipleShapes_PlacesAllThatFit()
+    {
+        using var container = new GridShape(10, 10);
+
+        var items = new[]
+        {
+            Shapes.Square(2),
+            Shapes.Single(),
+            Shapes.Line(3)
+        };
+
+        var positions = new (int, int)[items.Length];
+        var placed = container.PlaceMultipleShapes(items, positions);
+
+        Assert.AreEqual(3, placed);
+
+        // Verify all items were placed
+        for (int i = 0; i < placed; i++)
+        {
+            Assert.IsTrue(positions[i].Item1 >= 0);
+            Assert.IsTrue(positions[i].Item2 >= 0);
+        }
+
+        foreach (var item in items)
+        {
+            item.Dispose();
+        }
+    }
+
+    [Test]
+    public void PlaceMultipleShapes_StopsWhenContainerFull()
+    {
+        using var container = new GridShape(2, 2);
+
+        var items = new[]
+        {
+            Shapes.Square(2),
+            Shapes.Single()  // Won't fit after first item
+        };
+
+        var positions = new (int, int)[items.Length];
+        var placed = container.PlaceMultipleShapes(items, positions);
+
+        Assert.AreEqual(1, placed);
+
+        foreach (var item in items)
+        {
+            item.Dispose();
+        }
+    }
+
+    [Test]
+    public void CanPlaceItem_WithComplexShape_WorksCorrectly()
+    {
+        using var container = new GridShape(5, 5);
+        using var tShape = Shapes.TShape();
+
+        // T-shape: XXX
+        //           X
+        Assert.IsTrue(container.CanPlaceItem(tShape.AsReadOnly(), (0, 0)));
+        Assert.IsTrue(container.CanPlaceItem(tShape.AsReadOnly(), (2, 3)));
+
+        container.SetCell((1, 0), true);
+        Assert.IsFalse(container.CanPlaceItem(tShape.AsReadOnly(), (0, 0)));
+    }
+
+    [Test]
+    public void PlaceAndRemove_RoundTrip_RestoresOriginalState()
+    {
+        using var container = new GridShape(5, 5);
+        using var original = container.Clone();
+        using var item = Shapes.Cross();
+
+        container.PlaceItem(item.AsReadOnly(), (1, 1));
+        container.RemoveItem(item.AsReadOnly(), (1, 1));
+
+        for (int y = 0; y < 5; y++)
+        for (int x = 0; x < 5; x++)
+        {
+            Assert.AreEqual(original.GetCell((x, y)), container.GetCell((x, y)));
+        }
+    }
+}

--- a/Assets/Tests/Standard/GridBoardExtensionTests.cs
+++ b/Assets/Tests/Standard/GridBoardExtensionTests.cs
@@ -1,3 +1,4 @@
+using DopeGrid;
 using DopeGrid.Standard;
 using NUnit.Framework;
 
@@ -24,7 +25,7 @@ public class StandardGridBoardExtensionTests
         var pos = container.FindFirstFit(item.AsReadOnly());
 
         Assert.AreNotEqual((0, 0), pos);
-        Assert.IsTrue(pos.x >= 0 && pos.y >= 0);
+        Assert.IsTrue(pos.X >= 0 && pos.Y >= 0);
     }
 
     [Test]
@@ -160,7 +161,7 @@ public class StandardGridBoardExtensionTests
             Shapes.Line(3)
         };
 
-        var positions = new (int, int)[items.Length];
+        var positions = new GridPosition[items.Length];
         var placed = container.PlaceMultipleShapes(items, positions);
 
         Assert.AreEqual(3, placed);
@@ -168,8 +169,8 @@ public class StandardGridBoardExtensionTests
         // Verify all items were placed
         for (int i = 0; i < placed; i++)
         {
-            Assert.IsTrue(positions[i].Item1 >= 0);
-            Assert.IsTrue(positions[i].Item2 >= 0);
+            Assert.IsTrue(positions[i].X >= 0);
+            Assert.IsTrue(positions[i].Y >= 0);
         }
 
         foreach (var item in items)
@@ -189,7 +190,7 @@ public class StandardGridBoardExtensionTests
             Shapes.Single()  // Won't fit after first item
         };
 
-        var positions = new (int, int)[items.Length];
+        var positions = new GridPosition[items.Length];
         var placed = container.PlaceMultipleShapes(items, positions);
 
         Assert.AreEqual(1, placed);

--- a/Assets/Tests/Standard/GridBoardExtensionTests.cs.meta
+++ b/Assets/Tests/Standard/GridBoardExtensionTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 011401a861fce4036ab2e15ddb1a241b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Standard/GridBoardTests.cs
+++ b/Assets/Tests/Standard/GridBoardTests.cs
@@ -1,0 +1,229 @@
+using DopeGrid;
+using DopeGrid.Standard;
+using NUnit.Framework;
+
+public class StandardGridBoardTests
+{
+    private GridBoard _gridBoard;
+
+    [SetUp]
+    public void Setup()
+    {
+        _gridBoard = new GridBoard(10, 10);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _gridBoard.Dispose();
+    }
+
+    [Test]
+    public void Constructor_CreatesEmptyBoard()
+    {
+        Assert.AreEqual(10, _gridBoard.Width);
+        Assert.AreEqual(10, _gridBoard.Height);
+        Assert.AreEqual(0, _gridBoard.ItemCount);
+        Assert.AreEqual(100, _gridBoard.FreeSpace);
+    }
+
+    [Test]
+    public void Constructor_WithShape_ClonesShape()
+    {
+        using var containerShape = Shapes.Square(5);
+        using var board = new GridBoard(containerShape);
+
+        Assert.AreEqual(5, board.Width);
+        Assert.AreEqual(5, board.Height);
+        Assert.AreEqual(25, board.FreeSpace);
+    }
+
+    [Test]
+    public void TryAddItem_AddsItemSuccessfully()
+    {
+        var itemShape = Shapes.ImmutableSquare(2);
+
+        var added = _gridBoard.TryAddItem(itemShape);
+
+        Assert.IsTrue(added);
+        Assert.AreEqual(1, _gridBoard.ItemCount);
+        Assert.AreEqual(96, _gridBoard.FreeSpace);
+    }
+
+    [Test]
+    public void TryAddItemAt_AddsItemAtSpecificPosition()
+    {
+        var itemShape = Shapes.ImmutableSquare(2);
+
+        var added = _gridBoard.TryAddItemAt(itemShape, (3, 4));
+
+        Assert.IsTrue(added);
+        Assert.AreEqual(1, _gridBoard.ItemCount);
+        Assert.IsTrue(_gridBoard.IsCellOccupied((3, 4)));
+        Assert.IsTrue(_gridBoard.IsCellOccupied((4, 4)));
+        Assert.IsTrue(_gridBoard.IsCellOccupied((3, 5)));
+        Assert.IsTrue(_gridBoard.IsCellOccupied((4, 5)));
+    }
+
+    [Test]
+    public void TryAddItemAt_FailsWhenPositionOccupied()
+    {
+        var itemShape = Shapes.ImmutableSquare(2);
+
+        _gridBoard.TryAddItemAt(itemShape, (3, 4));
+        var secondAdd = _gridBoard.TryAddItemAt(itemShape, (3, 4));
+
+        Assert.IsFalse(secondAdd);
+        Assert.AreEqual(1, _gridBoard.ItemCount);
+    }
+
+    [Test]
+    public void TryAddItemAt_FailsWhenOutOfBounds()
+    {
+        var itemShape = Shapes.ImmutableSingle();
+
+        var added = _gridBoard.TryAddItemAt(itemShape, (10, 10));
+
+        Assert.IsFalse(added);
+        Assert.AreEqual(0, _gridBoard.ItemCount);
+    }
+
+    [Test]
+    public void TryAddItemAt_FailsWhenPartiallyOverlapping()
+    {
+        var itemShape = Shapes.ImmutableSquare(3);
+
+        _gridBoard.TryAddItemAt(Shapes.ImmutableSingle(), (2, 2));
+        var added = _gridBoard.TryAddItemAt(itemShape, (1, 1));
+
+        Assert.IsFalse(added);
+        Assert.AreEqual(1, _gridBoard.ItemCount);
+    }
+
+    [Test]
+    public void RemoveItem_RemovesItemSuccessfully()
+    {
+        var itemShape = Shapes.ImmutableSquare(2);
+        _gridBoard.TryAddItemAt(itemShape, (3, 4));
+
+        _gridBoard.RemoveItem(0);
+
+        Assert.AreEqual(0, _gridBoard.ItemCount);
+        Assert.AreEqual(100, _gridBoard.FreeSpace);
+        Assert.IsFalse(_gridBoard.IsCellOccupied((3, 4)));
+    }
+
+    [Test]
+    public void RemoveItem_MultipleItems_RemovesCorrectly()
+    {
+        var item1 = Shapes.ImmutableSquare(2);
+        var item2 = Shapes.ImmutableSingle();
+
+        _gridBoard.TryAddItemAt(item1, (0, 0));
+        _gridBoard.TryAddItemAt(item2, (5, 5));
+
+        _gridBoard.RemoveItem(0);
+
+        Assert.AreEqual(1, _gridBoard.ItemCount);
+        Assert.IsFalse(_gridBoard.IsCellOccupied((0, 0)));
+        Assert.IsTrue(_gridBoard.IsCellOccupied((5, 5)));
+    }
+
+    [Test]
+    public void Clear_RemovesAllItems()
+    {
+        _gridBoard.TryAddItem(Shapes.ImmutableSquare(2));
+        _gridBoard.TryAddItem(Shapes.ImmutableSingle());
+        _gridBoard.TryAddItem(Shapes.ImmutableLine(3));
+
+        _gridBoard.Clear();
+
+        Assert.AreEqual(0, _gridBoard.ItemCount);
+        Assert.AreEqual(100, _gridBoard.FreeSpace);
+    }
+
+    [Test]
+    public void Items_ReturnsAddedItems()
+    {
+        var item1 = Shapes.ImmutableSquare(2);
+        var item2 = Shapes.ImmutableSingle();
+
+        _gridBoard.TryAddItem(item1);
+        _gridBoard.TryAddItem(item2);
+
+        Assert.AreEqual(2, _gridBoard.Items.Count);
+        Assert.AreEqual(item1, _gridBoard.Items[0]);
+        Assert.AreEqual(item2, _gridBoard.Items[1]);
+    }
+
+    [Test]
+    public void ItemPositions_ReturnsCorrectPositions()
+    {
+        var item1 = Shapes.ImmutableSquare(2);
+        var item2 = Shapes.ImmutableSingle();
+
+        _gridBoard.TryAddItemAt(item1, (1, 2));
+        _gridBoard.TryAddItemAt(item2, (5, 6));
+
+        Assert.AreEqual(2, _gridBoard.ItemPositions.Count);
+        Assert.AreEqual((1, 2), _gridBoard.ItemPositions[0]);
+        Assert.AreEqual((5, 6), _gridBoard.ItemPositions[1]);
+    }
+
+    [Test]
+    public void TryAddItem_FindsFirstAvailablePosition()
+    {
+        var item = Shapes.ImmutableSingle();
+
+        _gridBoard.TryAddItem(item);
+        var pos = _gridBoard.ItemPositions[0];
+
+        Assert.AreEqual((0, 0), pos); // Should place at top-left first
+    }
+
+    [Test]
+    public void Clone_CreatesIndependentCopy()
+    {
+        _gridBoard.TryAddItem(Shapes.ImmutableSquare(2));
+
+        using var clone = _gridBoard.Clone();
+
+        Assert.AreEqual(_gridBoard.Width, clone.Width);
+        Assert.AreEqual(_gridBoard.Height, clone.Height);
+        Assert.AreEqual(_gridBoard.ItemCount, clone.ItemCount);
+
+        clone.TryAddItem(Shapes.ImmutableSingle());
+
+        Assert.AreEqual(1, _gridBoard.ItemCount);
+        Assert.AreEqual(2, clone.ItemCount);
+    }
+
+    [Test]
+    public void IsCellOccupied_ReturnsFalseForEmptyCell()
+    {
+        Assert.IsFalse(_gridBoard.IsCellOccupied((5, 5)));
+    }
+
+    [Test]
+    public void IsCellOccupied_ReturnsTrueForOccupiedCell()
+    {
+        _gridBoard.TryAddItemAt(Shapes.ImmutableSingle(), (5, 5));
+
+        Assert.IsTrue(_gridBoard.IsCellOccupied((5, 5)));
+    }
+
+    [Test]
+    public void FreeSpace_UpdatesCorrectly()
+    {
+        Assert.AreEqual(100, _gridBoard.FreeSpace);
+
+        _gridBoard.TryAddItem(Shapes.ImmutableSquare(2)); // 4 cells
+        Assert.AreEqual(96, _gridBoard.FreeSpace);
+
+        _gridBoard.TryAddItem(Shapes.ImmutableLine(3)); // 3 cells
+        Assert.AreEqual(93, _gridBoard.FreeSpace);
+
+        _gridBoard.RemoveItem(0); // Remove 4 cells
+        Assert.AreEqual(97, _gridBoard.FreeSpace);
+    }
+}

--- a/Assets/Tests/Standard/GridBoardTests.cs
+++ b/Assets/Tests/Standard/GridBoardTests.cs
@@ -175,8 +175,8 @@ public class StandardGridBoardTests
         _gridBoard.TryAddItemAt(item2, (5, 6));
 
         Assert.AreEqual(2, _gridBoard.ItemPositions.Count);
-        Assert.AreEqual((1, 2), _gridBoard.ItemPositions[0]);
-        Assert.AreEqual((5, 6), _gridBoard.ItemPositions[1]);
+        Assert.AreEqual(new GridPosition(1, 2), _gridBoard.ItemPositions[0]);
+        Assert.AreEqual(new GridPosition(5, 6), _gridBoard.ItemPositions[1]);
     }
 
     [Test]
@@ -187,7 +187,7 @@ public class StandardGridBoardTests
         _gridBoard.TryAddItem(item);
         var pos = _gridBoard.ItemPositions[0];
 
-        Assert.AreEqual((0, 0), pos); // Should place at top-left first
+        Assert.AreEqual(GridPosition.Zero, pos); // Should place at top-left first
     }
 
     [Test]

--- a/Assets/Tests/Standard/GridBoardTests.cs
+++ b/Assets/Tests/Standard/GridBoardTests.cs
@@ -30,12 +30,21 @@ public class StandardGridBoardTests
     [Test]
     public void Constructor_WithShape_ClonesShape()
     {
-        using var containerShape = Shapes.Square(5);
+        // Create a 5x5 container with some cells marked as obstacles
+        using var containerShape = new GridShape(5, 5);
+        containerShape.SetCell((0, 0), true); // Mark one cell as occupied/obstacle
+        containerShape.SetCell((4, 4), true); // Mark another cell as occupied/obstacle
+
         using var board = new GridBoard(containerShape);
 
         Assert.AreEqual(5, board.Width);
         Assert.AreEqual(5, board.Height);
-        Assert.AreEqual(25, board.FreeSpace);
+        Assert.AreEqual(23, board.FreeSpace); // 25 - 2 occupied cells
+
+        // Verify the occupied cells are preserved
+        Assert.IsTrue(board.IsCellOccupied((0, 0)));
+        Assert.IsTrue(board.IsCellOccupied((4, 4)));
+        Assert.IsFalse(board.IsCellOccupied((2, 2)));
     }
 
     [Test]

--- a/Assets/Tests/Standard/GridBoardTests.cs.meta
+++ b/Assets/Tests/Standard/GridBoardTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cb3dcb30e33f44de291e25aed0317cab
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Standard/GridShapeTests.cs
+++ b/Assets/Tests/Standard/GridShapeTests.cs
@@ -1,0 +1,241 @@
+using DopeGrid.Standard;
+using NUnit.Framework;
+
+public class StandardGridShapeTests
+{
+    [Test]
+    public void Constructor_CreatesEmptyGrid()
+    {
+        using var grid = new GridShape(5, 5);
+
+        Assert.AreEqual(5, grid.Width);
+        Assert.AreEqual(5, grid.Height);
+        Assert.AreEqual(25, grid.Size);
+
+        for (var y = 0; y < 5; y++)
+        for (var x = 0; x < 5; x++)
+            Assert.IsFalse(grid.GetCell((x, y)));
+    }
+
+    [Test]
+    public void Constructor_WithPooling_UsesArrayPool()
+    {
+        using var gridPooled = new GridShape(5, 5);
+        using var gridNonPooled = new GridShape(5, 5);
+
+        Assert.AreEqual(5, gridPooled.Width);
+        Assert.AreEqual(5, gridNonPooled.Width);
+    }
+
+    [Test]
+    public void SetCell_GetCell_WorkCorrectly()
+    {
+        using var grid = new GridShape(3, 3);
+
+        grid.SetCell((0, 0), true);
+        grid.SetCell((1, 1), true);
+        grid.SetCell((2, 2), true);
+
+        Assert.IsTrue(grid.GetCell((0, 0)));
+        Assert.IsTrue(grid.GetCell((1, 1)));
+        Assert.IsTrue(grid.GetCell((2, 2)));
+        Assert.IsFalse(grid.GetCell((0, 1)));
+        Assert.IsFalse(grid.GetCell((1, 0)));
+    }
+
+    [Test]
+    public void Indexer_WorksCorrectly()
+    {
+        var grid = new GridShape(3, 3);
+        try
+        {
+            grid[1, 1] = true;
+            grid[(2, 2)] = true;
+
+            Assert.IsTrue(grid[1, 1]);
+            Assert.IsTrue(grid[(2, 2)]);
+            Assert.IsFalse(grid[0, 0]);
+        }
+        finally
+        {
+            grid.Dispose();
+        }
+    }
+
+    [Test]
+    public void Clear_ResetsAllCells()
+    {
+        using var grid = new GridShape(4, 4);
+
+        grid.SetCell((0, 0), true);
+        grid.SetCell((1, 1), true);
+        grid.SetCell((2, 2), true);
+        grid.SetCell((3, 3), true);
+
+        grid.Clear();
+
+        for (var y = 0; y < 4; y++)
+        for (var x = 0; x < 4; x++)
+            Assert.IsFalse(grid.GetCell((x, y)));
+    }
+
+    [Test]
+    public void Fill_SetsAllCells()
+    {
+        using var grid = new GridShape(3, 3);
+
+        grid.Fill(true);
+
+        for (var y = 0; y < 3; y++)
+        for (var x = 0; x < 3; x++)
+            Assert.IsTrue(grid.GetCell((x, y)));
+
+        grid.Fill(false);
+
+        for (var y = 0; y < 3; y++)
+        for (var x = 0; x < 3; x++)
+            Assert.IsFalse(grid.GetCell((x, y)));
+    }
+
+    [Test]
+    public void FillRect_FillsRectangleArea()
+    {
+        using var grid = new GridShape(5, 5);
+
+        grid.FillRect(1, 1, 3, 2, true);
+
+        Assert.IsTrue(grid.GetCell((1, 1)));
+        Assert.IsTrue(grid.GetCell((2, 1)));
+        Assert.IsTrue(grid.GetCell((3, 1)));
+        Assert.IsTrue(grid.GetCell((1, 2)));
+        Assert.IsTrue(grid.GetCell((2, 2)));
+        Assert.IsTrue(grid.GetCell((3, 2)));
+
+        Assert.IsFalse(grid.GetCell((0, 0)));
+        Assert.IsFalse(grid.GetCell((4, 4)));
+    }
+
+    [Test]
+    public void Clone_CreatesIdenticalCopy()
+    {
+        using var original = new GridShape(3, 4);
+        original.SetCell((0, 0), true);
+        original.SetCell((1, 2), true);
+        original.SetCell((2, 3), true);
+
+        using var clone = original.Clone();
+
+        Assert.AreEqual(original.Width, clone.Width);
+        Assert.AreEqual(original.Height, clone.Height);
+
+        for (var y = 0; y < original.Height; y++)
+        for (var x = 0; x < original.Width; x++)
+        {
+            var pos = (x, y);
+            Assert.AreEqual(original.GetCell(pos), clone.GetCell(pos));
+        }
+    }
+
+    [Test]
+    public void Clone_ModificationsDoNotAffectOriginal()
+    {
+        using var original = new GridShape(3, 3);
+        original.SetCell((1, 1), true);
+
+        using var clone = original.Clone();
+        clone.SetCell((0, 0), true);
+        clone.SetCell((1, 1), false);
+
+        Assert.IsTrue(original.GetCell((1, 1)));
+        Assert.IsFalse(original.GetCell((0, 0)));
+
+        Assert.IsFalse(clone.GetCell((1, 1)));
+        Assert.IsTrue(clone.GetCell((0, 0)));
+    }
+
+    [Test]
+    public void OccupiedSpaceCount_ReturnsCorrectCount()
+    {
+        using var grid = new GridShape(4, 4);
+
+        Assert.AreEqual(0, grid.OccupiedSpaceCount);
+
+        grid.SetCell((0, 0), true);
+        grid.SetCell((1, 1), true);
+        grid.SetCell((2, 2), true);
+
+        Assert.AreEqual(3, grid.OccupiedSpaceCount);
+        Assert.AreEqual(13, grid.FreeSpaceCount);
+    }
+
+    [Test]
+    public void CopyTo_CopiesCorrectly()
+    {
+        using var source = new GridShape(3, 3);
+        source.SetCell((0, 0), true);
+        source.SetCell((1, 1), true);
+        source.SetCell((2, 2), true);
+
+        using var dest = new GridShape(3, 3);
+        source.CopyTo(dest);
+
+        for (var y = 0; y < 3; y++)
+        for (var x = 0; x < 3; x++)
+        {
+            Assert.AreEqual(source.GetCell((x, y)), dest.GetCell((x, y)));
+        }
+    }
+
+    [Test]
+    public void CopyTo_ThrowsOnDifferentDimensions()
+    {
+        using var source = new GridShape(3, 3);
+        using var dest = new GridShape(4, 4);
+
+        Assert.Throws<System.ArgumentException>(() => source.CopyTo(dest));
+    }
+
+    [Test]
+    public void Dispose_CanBeCalledMultipleTimes()
+    {
+        var grid = new GridShape(3, 3);
+        grid.Dispose();
+        grid.Dispose(); // Should not throw
+
+        Assert.Pass();
+    }
+
+    [Test]
+    public void ReadOnly_AsReadOnly_ReturnsReadOnlyView()
+    {
+        using var grid = new GridShape(3, 3);
+        grid.SetCell((1, 1), true);
+
+        var readOnly = grid.AsReadOnly();
+
+        Assert.AreEqual(3, readOnly.Width);
+        Assert.AreEqual(3, readOnly.Height);
+        Assert.IsTrue(readOnly.GetCell((1, 1)));
+        Assert.IsFalse(readOnly.GetCell((0, 0)));
+    }
+
+    [Test]
+    public void ReadOnly_Equals_WorksCorrectly()
+    {
+        using var grid1 = new GridShape(2, 2);
+        grid1.SetCell((0, 0), true);
+
+        using var grid2 = new GridShape(2, 2);
+        grid2.SetCell((0, 0), true);
+
+        using var grid3 = new GridShape(2, 2);
+        grid3.SetCell((1, 1), true);
+
+        var ro1 = grid1.AsReadOnly();
+        var ro2 = grid2.AsReadOnly();
+        var ro3 = grid3.AsReadOnly();
+
+        Assert.IsTrue(ro1.Equals(ro2));
+        Assert.IsFalse(ro1.Equals(ro3));
+    }
+}

--- a/Assets/Tests/Standard/GridShapeTests.cs.meta
+++ b/Assets/Tests/Standard/GridShapeTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2a0451e6695574a90b53e349bfa7ea68
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Standard/ImmutableGridShapeTests.cs
+++ b/Assets/Tests/Standard/ImmutableGridShapeTests.cs
@@ -1,0 +1,201 @@
+using DopeGrid;
+using DopeGrid.Standard;
+using NUnit.Framework;
+
+public class StandardImmutableGridShapeTests
+{
+    [Test]
+    public void GetOrCreateImmutable_CreatesSameIdForIdenticalShapes()
+    {
+        using var shape1 = Shapes.Square(3);
+        using var shape2 = Shapes.Square(3);
+
+        var immutable1 = shape1.GetOrCreateImmutable();
+        var immutable2 = shape2.GetOrCreateImmutable();
+
+        Assert.AreEqual(immutable1.Id, immutable2.Id);
+    }
+
+    [Test]
+    public void GetOrCreateImmutable_CreatesDifferentIdForDifferentShapes()
+    {
+        using var shape1 = Shapes.Square(3);
+        using var shape2 = Shapes.Line(3);
+
+        var immutable1 = shape1.GetOrCreateImmutable();
+        var immutable2 = shape2.GetOrCreateImmutable();
+
+        Assert.AreNotEqual(immutable1.Id, immutable2.Id);
+    }
+
+    [Test]
+    public void GetOrCreateImmutable_RequiresTrimmedShape()
+    {
+        using var untrimmed = new GridShape(5, 5);
+        untrimmed.SetCell((2, 2), true);
+
+        Assert.Throws<System.ArgumentException>(() => untrimmed.GetOrCreateImmutable());
+    }
+
+    [Test]
+    public void ImmutableShape_PropertiesAccessible()
+    {
+        var immutable = Shapes.ImmutableSquare(3);
+
+        Assert.AreEqual(3, immutable.Width);
+        Assert.AreEqual(3, immutable.Height);
+        Assert.AreEqual(9, immutable.Size);
+        Assert.AreEqual(9, immutable.OccupiedSpaceCount);
+        Assert.AreEqual(0, immutable.FreeSpaceCount);
+    }
+
+    [Test]
+    public void ImmutableShape_GetCell_WorksCorrectly()
+    {
+        var immutable = Shapes.ImmutableLShape();
+
+        Assert.IsTrue(immutable.GetCell((0, 0)));
+        Assert.IsTrue(immutable.GetCell((0, 1)));
+        Assert.IsTrue(immutable.GetCell((1, 1)));
+        Assert.IsFalse(immutable.GetCell((1, 0)));
+    }
+
+    [Test]
+    public void ImmutableShape_Rotate90_CreatesRotatedShape()
+    {
+        var original = Shapes.ImmutableLine(3);
+        var rotated = original.Rotate90();
+
+        Assert.AreEqual(1, rotated.Width);
+        Assert.AreEqual(3, rotated.Height);
+        Assert.AreEqual(original.OccupiedSpaceCount, rotated.OccupiedSpaceCount);
+    }
+
+    [Test]
+    public void ImmutableShape_Rotate90_IsCached()
+    {
+        var original = Shapes.ImmutableSquare(2);
+        var rotated1 = original.Rotate90();
+        var rotated2 = original.Rotate90();
+
+        Assert.AreEqual(rotated1.Id, rotated2.Id);
+    }
+
+    [Test]
+    public void ImmutableShape_Flip_CreatesFlippedShape()
+    {
+        var original = Shapes.ImmutableLShape();
+        var flipped = original.Flip();
+
+        Assert.AreEqual(original.Width, flipped.Width);
+        Assert.AreEqual(original.Height, flipped.Height);
+        Assert.AreEqual(original.OccupiedSpaceCount, flipped.OccupiedSpaceCount);
+    }
+
+    [Test]
+    public void ImmutableShape_Flip_IsCached()
+    {
+        var original = Shapes.ImmutableLShape();
+        var flipped1 = original.Flip();
+        var flipped2 = original.Flip();
+
+        Assert.AreEqual(flipped1.Id, flipped2.Id);
+    }
+
+    [Test]
+    public void ImmutableShape_FlipTwice_ReturnsOriginal()
+    {
+        var original = Shapes.ImmutableLShape();
+        var flipped = original.Flip();
+        var flippedBack = flipped.Flip();
+
+        Assert.AreEqual(original.Id, flippedBack.Id);
+    }
+
+    [Test]
+    public void ImmutableShape_ToReadOnlyGridShape_WorksCorrectly()
+    {
+        var immutable = Shapes.ImmutableSquare(2);
+        var readOnly = immutable.ToReadOnlyGridShape();
+
+        Assert.AreEqual(2, readOnly.Width);
+        Assert.AreEqual(2, readOnly.Height);
+
+        for (int y = 0; y < 2; y++)
+        for (int x = 0; x < 2; x++)
+            Assert.IsTrue(readOnly.GetCell((x, y)));
+    }
+
+    [Test]
+    public void ImmutableShape_CopyTo_CopiesCorrectly()
+    {
+        var immutable = Shapes.ImmutableLShape();
+        using var target = new GridShape(2, 2);
+
+        immutable.CopyTo(target);
+
+        Assert.IsTrue(target.GetCell((0, 0)));
+        Assert.IsTrue(target.GetCell((0, 1)));
+        Assert.IsTrue(target.GetCell((1, 1)));
+        Assert.IsFalse(target.GetCell((1, 0)));
+    }
+
+    [Test]
+    public void ImmutableShape_Empty_IsEmpty()
+    {
+        var empty = ImmutableGridShape.Empty;
+
+        Assert.AreEqual(0, empty.Width);
+        Assert.AreEqual(0, empty.Height);
+        Assert.IsTrue(empty.IsEmpty);
+    }
+
+    [Test]
+    public void ImmutableShape_GetIndex_CalculatesCorrectly()
+    {
+        var shape = Shapes.ImmutableSquare(3);
+
+        Assert.AreEqual(0, shape.GetIndex((0, 0)));
+        Assert.AreEqual(1, shape.GetIndex((1, 0)));
+        Assert.AreEqual(3, shape.GetIndex((0, 1)));
+        Assert.AreEqual(4, shape.GetIndex((1, 1)));
+    }
+
+    [Test]
+    public void GetRotatedShape_ReturnsCorrectRotation()
+    {
+        var original = Shapes.ImmutableLine(3);
+
+        var rotated90 = original.GetRotatedShape(RotationDegree.Clockwise90);
+        Assert.AreEqual(1, rotated90.Width);
+        Assert.AreEqual(3, rotated90.Height);
+
+        var rotated180 = original.GetRotatedShape(RotationDegree.Clockwise180);
+        Assert.AreEqual(3, rotated180.Width);
+        Assert.AreEqual(1, rotated180.Height);
+
+        var rotated270 = original.GetRotatedShape(RotationDegree.Clockwise270);
+        Assert.AreEqual(1, rotated270.Width);
+        Assert.AreEqual(3, rotated270.Height);
+
+        var rotatedNone = original.GetRotatedShape(RotationDegree.None);
+        Assert.AreEqual(original.Id, rotatedNone.Id);
+    }
+
+    [Test]
+    public void ImmutableShape_MultipleRotations_MaintainOccupiedCount()
+    {
+        var original = Shapes.ImmutableLShape();
+        var originalCount = original.OccupiedSpaceCount;
+
+        var rotated90 = original.Rotate90();
+        var rotated180 = rotated90.Rotate90();
+        var rotated270 = rotated180.Rotate90();
+        var rotated360 = rotated270.Rotate90();
+
+        Assert.AreEqual(originalCount, rotated90.OccupiedSpaceCount);
+        Assert.AreEqual(originalCount, rotated180.OccupiedSpaceCount);
+        Assert.AreEqual(originalCount, rotated270.OccupiedSpaceCount);
+        Assert.AreEqual(originalCount, rotated360.OccupiedSpaceCount);
+    }
+}

--- a/Assets/Tests/Standard/ImmutableGridShapeTests.cs.meta
+++ b/Assets/Tests/Standard/ImmutableGridShapeTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bc4b2b5f065b74306b4f50a500839b6f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Standard/ShapesTests.cs
+++ b/Assets/Tests/Standard/ShapesTests.cs
@@ -1,0 +1,233 @@
+using DopeGrid;
+using DopeGrid.Standard;
+using NUnit.Framework;
+
+[TestFixture]
+public class StandardShapesTests
+{
+    [Test]
+    public void Single_CreatesCorrectShape()
+    {
+        using var shape = Shapes.Single();
+
+        Assert.AreEqual(1, shape.Width);
+        Assert.AreEqual(1, shape.Height);
+        Assert.IsTrue(shape.GetCell((0, 0)));
+        Assert.AreEqual(1, shape.OccupiedSpaceCount);
+    }
+
+    [Test]
+    public void Line_CreatesCorrectShape()
+    {
+        using var shape = Shapes.Line(4);
+
+        Assert.AreEqual(4, shape.Width);
+        Assert.AreEqual(1, shape.Height);
+        Assert.AreEqual(4, shape.OccupiedSpaceCount);
+
+        for (int x = 0; x < 4; x++)
+            Assert.IsTrue(shape.GetCell((x, 0)));
+    }
+
+    [Test]
+    public void Square_CreatesCorrectShape()
+    {
+        using var shape = Shapes.Square(3);
+
+        Assert.AreEqual(3, shape.Width);
+        Assert.AreEqual(3, shape.Height);
+        Assert.AreEqual(9, shape.OccupiedSpaceCount);
+
+        for (int y = 0; y < 3; y++)
+        for (int x = 0; x < 3; x++)
+            Assert.IsTrue(shape.GetCell((x, y)));
+    }
+
+    [Test]
+    public void LShape_CreatesCorrectShape()
+    {
+        using var shape = Shapes.LShape();
+
+        Assert.AreEqual(2, shape.Width);
+        Assert.AreEqual(2, shape.Height);
+        Assert.AreEqual(3, shape.OccupiedSpaceCount);
+
+        Assert.IsTrue(shape.GetCell((0, 0)));
+        Assert.IsTrue(shape.GetCell((0, 1)));
+        Assert.IsTrue(shape.GetCell((1, 1)));
+        Assert.IsFalse(shape.GetCell((1, 0)));
+    }
+
+    [Test]
+    public void TShape_CreatesCorrectShape()
+    {
+        using var shape = Shapes.TShape();
+
+        Assert.AreEqual(3, shape.Width);
+        Assert.AreEqual(2, shape.Height);
+        Assert.AreEqual(4, shape.OccupiedSpaceCount);
+
+        Assert.IsTrue(shape.GetCell((0, 0)));
+        Assert.IsTrue(shape.GetCell((1, 0)));
+        Assert.IsTrue(shape.GetCell((2, 0)));
+        Assert.IsTrue(shape.GetCell((1, 1)));
+    }
+
+    [Test]
+    public void Cross_CreatesCorrectShape()
+    {
+        using var shape = Shapes.Cross();
+
+        Assert.AreEqual(3, shape.Width);
+        Assert.AreEqual(3, shape.Height);
+        Assert.AreEqual(5, shape.OccupiedSpaceCount);
+
+        Assert.IsTrue(shape.GetCell((1, 0)));
+        Assert.IsTrue(shape.GetCell((0, 1)));
+        Assert.IsTrue(shape.GetCell((1, 1)));
+        Assert.IsTrue(shape.GetCell((2, 1)));
+        Assert.IsTrue(shape.GetCell((1, 2)));
+    }
+
+    [Test]
+    public void Rotate_Line_90Degrees()
+    {
+        using var shape = Shapes.Line(3);
+        using var rotated = shape.Rotate(RotationDegree.Clockwise90);
+
+        Assert.AreEqual(1, rotated.Width);
+        Assert.AreEqual(3, rotated.Height);
+        Assert.IsTrue(rotated.GetCell((0, 0)));
+        Assert.IsTrue(rotated.GetCell((0, 1)));
+        Assert.IsTrue(rotated.GetCell((0, 2)));
+        Assert.AreEqual(shape.OccupiedSpaceCount, rotated.OccupiedSpaceCount);
+    }
+
+    [Test]
+    public void Rotate_LShape_90Degrees()
+    {
+        using var shape = Shapes.LShape();
+        using var rotated = shape.Rotate(RotationDegree.Clockwise90);
+
+        Assert.AreEqual(2, rotated.Width);
+        Assert.AreEqual(2, rotated.Height);
+        Assert.AreEqual(3, rotated.OccupiedSpaceCount);
+
+        // L rotated 90 clockwise becomes different orientation
+        Assert.IsTrue(rotated.GetCell((0, 0)));
+        Assert.IsTrue(rotated.GetCell((1, 0)));
+        Assert.IsTrue(rotated.GetCell((0, 1)));
+    }
+
+    [Test]
+    public void Rotate_180Degrees_FlipsCompletely()
+    {
+        using var shape = Shapes.Line(3);
+        using var rotated = shape.Rotate(RotationDegree.Clockwise180);
+
+        Assert.AreEqual(3, rotated.Width);
+        Assert.AreEqual(1, rotated.Height);
+        Assert.AreEqual(shape.OccupiedSpaceCount, rotated.OccupiedSpaceCount);
+    }
+
+    [Test]
+    public void Rotate_270Degrees()
+    {
+        using var shape = Shapes.Line(3);
+        using var rotated = shape.Rotate(RotationDegree.Clockwise270);
+
+        Assert.AreEqual(1, rotated.Width);
+        Assert.AreEqual(3, rotated.Height);
+        Assert.AreEqual(shape.OccupiedSpaceCount, rotated.OccupiedSpaceCount);
+    }
+
+    [Test]
+    public void Flip_Horizontal()
+    {
+        using var shape = Shapes.LShape();
+        using var flipped = shape.Flip(FlipAxis.Horizontal);
+
+        Assert.AreEqual(shape.Width, flipped.Width);
+        Assert.AreEqual(shape.Height, flipped.Height);
+        Assert.AreEqual(shape.OccupiedSpaceCount, flipped.OccupiedSpaceCount);
+
+        // Original L: (0,0), (0,1), (1,1)
+        // Flipped horizontally: (1,0), (1,1), (0,1)
+        Assert.IsTrue(flipped.GetCell((1, 0)));
+        Assert.IsTrue(flipped.GetCell((1, 1)));
+        Assert.IsTrue(flipped.GetCell((0, 1)));
+    }
+
+    [Test]
+    public void Flip_Vertical()
+    {
+        using var shape = Shapes.LShape();
+        using var flipped = shape.Flip(FlipAxis.Vertical);
+
+        Assert.AreEqual(shape.Width, flipped.Width);
+        Assert.AreEqual(shape.Height, flipped.Height);
+        Assert.AreEqual(shape.OccupiedSpaceCount, flipped.OccupiedSpaceCount);
+    }
+
+    [Test]
+    public void Trim_RemovesEmptyBorders()
+    {
+        using var shape = new GridShape(5, 5);
+        shape.SetCell((2, 2), true);
+        shape.SetCell((2, 3), true);
+        shape.SetCell((3, 2), true);
+
+        using var trimmed = shape.AsReadOnly().Trim();
+
+        Assert.AreEqual(2, trimmed.Width);
+        Assert.AreEqual(2, trimmed.Height);
+        Assert.AreEqual(3, trimmed.OccupiedSpaceCount);
+    }
+
+    [Test]
+    public void Trim_EmptyShape_ReturnsEmpty()
+    {
+        using var shape = new GridShape(5, 5);
+        using var trimmed = shape.AsReadOnly().Trim();
+
+        Assert.AreEqual(0, trimmed.Width);
+        Assert.AreEqual(0, trimmed.Height);
+    }
+
+    [Test]
+    public void Trim_AlreadyTrimmed_ReturnsClone()
+    {
+        using var shape = Shapes.Square(3);
+        using var trimmed = shape.AsReadOnly().Trim();
+
+        Assert.AreEqual(shape.Width, trimmed.Width);
+        Assert.AreEqual(shape.Height, trimmed.Height);
+    }
+
+    [Test]
+    public void IsTrimmed_DetectsCorrectly()
+    {
+        using var untrimmed = new GridShape(5, 5);
+        untrimmed.SetCell((2, 2), true);
+        Assert.IsFalse(untrimmed.IsTrimmed());
+
+        using var trimmed = Shapes.Square(3);
+        Assert.IsTrue(trimmed.IsTrimmed());
+    }
+
+    [Test]
+    public void GetRotatedDimensions_ReturnsCorrectDimensions()
+    {
+        using var shape = new GridShape(3, 5);
+        var ro = shape.AsReadOnly();
+
+        var dim90 = ro.GetRotatedDimensions(RotationDegree.Clockwise90);
+        Assert.AreEqual((5, 3), dim90);
+
+        var dim180 = ro.GetRotatedDimensions(RotationDegree.Clockwise180);
+        Assert.AreEqual((3, 5), dim180);
+
+        var dim270 = ro.GetRotatedDimensions(RotationDegree.Clockwise270);
+        Assert.AreEqual((5, 3), dim270);
+    }
+}

--- a/Assets/Tests/Standard/ShapesTests.cs.meta
+++ b/Assets/Tests/Standard/ShapesTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1084aaef20dc042fbbe79de016c5eb89
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Standard/ValueGridShapeTests.cs
+++ b/Assets/Tests/Standard/ValueGridShapeTests.cs
@@ -7,7 +7,7 @@ public class StandardValueGridShapeTests
     [Test]
     public void Constructor_CreatesEmptyGrid()
     {
-        var grid = new ValueGridShape<int>(3, 4);
+        using using var grid = new ValueGridShape<int>(3, 4);
 
         Assert.AreEqual(3, grid.Width);
         Assert.AreEqual(4, grid.Height);
@@ -21,7 +21,7 @@ public class StandardValueGridShapeTests
     [Test]
     public void Constructor_WithDefaultValue_FillsGrid()
     {
-        var grid = new ValueGridShape<int>(3, 3, 42);
+        using var grid = new ValueGridShape<int>(3, 3, 42);
 
         for (int y = 0; y < 3; y++)
         for (int x = 0; x < 3; x++)
@@ -31,7 +31,7 @@ public class StandardValueGridShapeTests
     [Test]
     public void SetValue_GetValue_WorkCorrectly()
     {
-        var grid = new ValueGridShape<string>(2, 2);
+        using var grid = new ValueGridShape<string>(2, 2);
 
         grid.SetValue((0, 0), "A");
         grid.SetValue((1, 1), "B");
@@ -44,7 +44,7 @@ public class StandardValueGridShapeTests
     [Test]
     public void Indexer_WorksCorrectly()
     {
-        var grid = new ValueGridShape<int>(3, 3);
+        using var grid = new ValueGridShape<int>(3, 3);
 
         grid[1, 1] = 5;
         grid[(2, 2)] = 10;
@@ -57,7 +57,7 @@ public class StandardValueGridShapeTests
     [Test]
     public void Fill_FillsAllCells()
     {
-        var grid = new ValueGridShape<int>(3, 3);
+        using var grid = new ValueGridShape<int>(3, 3);
 
         grid.Fill(7);
 
@@ -69,7 +69,7 @@ public class StandardValueGridShapeTests
     [Test]
     public void FillRect_FillsRectangleArea()
     {
-        var grid = new ValueGridShape<int>(5, 5);
+        using var grid = new ValueGridShape<int>(5, 5);
 
         grid.FillRect(1, 1, 3, 2, 99);
 
@@ -84,7 +84,7 @@ public class StandardValueGridShapeTests
     [Test]
     public void Clear_ResetsToDefault()
     {
-        var grid = new ValueGridShape<int>(3, 3);
+        using var grid = new ValueGridShape<int>(3, 3);
         grid.Fill(5);
 
         grid.Clear();
@@ -97,7 +97,7 @@ public class StandardValueGridShapeTests
     [Test]
     public void Contains_DetectsBounds()
     {
-        var grid = new ValueGridShape<int>(3, 3);
+        using var grid = new ValueGridShape<int>(3, 3);
 
         Assert.IsTrue(grid.Contains((0, 0)));
         Assert.IsTrue(grid.Contains((2, 2)));
@@ -150,7 +150,7 @@ public class StandardValueGridShapeTests
     [Test]
     public void CountValue_CountsCorrectly()
     {
-        var grid = new ValueGridShape<int>(3, 3);
+        using var grid = new ValueGridShape<int>(3, 3);
         grid.SetValue((0, 0), 5);
         grid.SetValue((1, 1), 5);
         grid.SetValue((2, 2), 10);
@@ -163,7 +163,7 @@ public class StandardValueGridShapeTests
     [Test]
     public void CountWhere_CountsWithPredicate()
     {
-        var grid = new ValueGridShape<int>(3, 3);
+        using var grid = new ValueGridShape<int>(3, 3);
         grid.SetValue((0, 0), 5);
         grid.SetValue((1, 1), 10);
         grid.SetValue((2, 2), 15);
@@ -175,7 +175,7 @@ public class StandardValueGridShapeTests
     [Test]
     public void Any_DetectsMatchingElements()
     {
-        var grid = new ValueGridShape<int>(2, 2);
+        using var grid = new ValueGridShape<int>(2, 2);
         grid.SetValue((1, 1), 42);
 
         Assert.IsTrue(grid.Any(x => x == 42));
@@ -185,7 +185,7 @@ public class StandardValueGridShapeTests
     [Test]
     public void All_ChecksAllElements()
     {
-        var grid = new ValueGridShape<int>(2, 2, 5);
+        using var grid = new ValueGridShape<int>(2, 2, 5);
 
         Assert.IsTrue(grid.All(x => x == 5));
 
@@ -201,7 +201,7 @@ public class StandardValueGridShapeTests
         valueGrid.SetValue((1, 1), 1);
         valueGrid.SetValue((2, 2), 0);
 
-        var gridShape = valueGrid.ToGridShape(1);
+        using var gridShape = valueGrid.ToGridShape(1);
 
         Assert.AreEqual(3, gridShape.Width);
         Assert.AreEqual(3, gridShape.Height);
@@ -218,7 +218,7 @@ public class StandardValueGridShapeTests
         valueGrid.SetValue((1, 1), 10);
         valueGrid.SetValue((2, 2), 3);
 
-        var gridShape = valueGrid.ToGridShape(x => x > 5);
+        using var gridShape = valueGrid.ToGridShape(x => x > 5);
 
         Assert.IsFalse(gridShape.GetCell((0, 0)));
         Assert.IsTrue(gridShape.GetCell((1, 1)));
@@ -228,7 +228,7 @@ public class StandardValueGridShapeTests
     [Test]
     public void FromGridShape_ConvertsCorrectly()
     {
-        var gridShape = Shapes.LShape();
+        using var gridShape = Shapes.LShape();
         using var valueGrid = new ValueGridShape<int>(2, 2);
 
         valueGrid.FromGridShape(gridShape, 1, 0);
@@ -242,7 +242,7 @@ public class StandardValueGridShapeTests
     [Test]
     public void AsReadOnly_ReturnsReadOnlyView()
     {
-        var grid = new ValueGridShape<int>(2, 2);
+        using var grid = new ValueGridShape<int>(2, 2);
         grid.SetValue((1, 1), 42);
 
         var readOnly = grid.AsReadOnly();

--- a/Assets/Tests/Standard/ValueGridShapeTests.cs
+++ b/Assets/Tests/Standard/ValueGridShapeTests.cs
@@ -1,0 +1,255 @@
+using DopeGrid.Standard;
+using NUnit.Framework;
+using System;
+
+public class StandardValueGridShapeTests
+{
+    [Test]
+    public void Constructor_CreatesEmptyGrid()
+    {
+        using var grid = new ValueGridShape<int>(3, 4);
+
+        Assert.AreEqual(3, grid.Width);
+        Assert.AreEqual(4, grid.Height);
+        Assert.AreEqual(12, grid.Size);
+
+        for (int y = 0; y < 4; y++)
+        for (int x = 0; x < 3; x++)
+            Assert.AreEqual(0, grid.GetValue((x, y)));
+    }
+
+    [Test]
+    public void Constructor_WithDefaultValue_FillsGrid()
+    {
+        using var grid = new ValueGridShape<int>(3, 3, 42);
+
+        for (int y = 0; y < 3; y++)
+        for (int x = 0; x < 3; x++)
+            Assert.AreEqual(42, grid.GetValue((x, y)));
+    }
+
+    [Test]
+    public void SetValue_GetValue_WorkCorrectly()
+    {
+        using var grid = new ValueGridShape<string>(2, 2);
+
+        grid.SetValue((0, 0), "A");
+        grid.SetValue((1, 1), "B");
+
+        Assert.AreEqual("A", grid.GetValue((0, 0)));
+        Assert.AreEqual("B", grid.GetValue((1, 1)));
+        Assert.AreEqual(null, grid.GetValue((0, 1)));
+    }
+
+    [Test]
+    public void Indexer_WorksCorrectly()
+    {
+        using var grid = new ValueGridShape<int>(3, 3);
+
+        grid[1, 1] = 5;
+        grid[(2, 2)] = 10;
+
+        Assert.AreEqual(5, grid[1, 1]);
+        Assert.AreEqual(10, grid[(2, 2)]);
+        Assert.AreEqual(0, grid[0, 0]);
+    }
+
+    [Test]
+    public void Fill_FillsAllCells()
+    {
+        using var grid = new ValueGridShape<int>(3, 3);
+
+        grid.Fill(7);
+
+        for (int y = 0; y < 3; y++)
+        for (int x = 0; x < 3; x++)
+            Assert.AreEqual(7, grid.GetValue((x, y)));
+    }
+
+    [Test]
+    public void FillRect_FillsRectangleArea()
+    {
+        using var grid = new ValueGridShape<int>(5, 5);
+
+        grid.FillRect(1, 1, 3, 2, 99);
+
+        Assert.AreEqual(99, grid.GetValue((1, 1)));
+        Assert.AreEqual(99, grid.GetValue((2, 1)));
+        Assert.AreEqual(99, grid.GetValue((3, 1)));
+        Assert.AreEqual(99, grid.GetValue((1, 2)));
+        Assert.AreEqual(0, grid.GetValue((0, 0)));
+        Assert.AreEqual(0, grid.GetValue((4, 4)));
+    }
+
+    [Test]
+    public void Clear_ResetsToDefault()
+    {
+        using var grid = new ValueGridShape<int>(3, 3);
+        grid.Fill(5);
+
+        grid.Clear();
+
+        for (int y = 0; y < 3; y++)
+        for (int x = 0; x < 3; x++)
+            Assert.AreEqual(0, grid.GetValue((x, y)));
+    }
+
+    [Test]
+    public void Contains_DetectsBounds()
+    {
+        using var grid = new ValueGridShape<int>(3, 3);
+
+        Assert.IsTrue(grid.Contains((0, 0)));
+        Assert.IsTrue(grid.Contains((2, 2)));
+        Assert.IsFalse(grid.Contains((3, 0)));
+        Assert.IsFalse(grid.Contains((0, 3)));
+        Assert.IsFalse(grid.Contains((-1, 0)));
+    }
+
+    [Test]
+    public void Clone_CreatesIndependentCopy()
+    {
+        using var original = new ValueGridShape<int>(2, 2);
+        original.SetValue((0, 0), 1);
+        original.SetValue((1, 1), 2);
+
+        using var clone = original.Clone();
+
+        Assert.AreEqual(original.Width, clone.Width);
+        Assert.AreEqual(original.Height, clone.Height);
+        Assert.AreEqual(1, clone.GetValue((0, 0)));
+        Assert.AreEqual(2, clone.GetValue((1, 1)));
+
+        clone.SetValue((0, 0), 99);
+        Assert.AreEqual(1, original.GetValue((0, 0)));
+    }
+
+    [Test]
+    public void CopyTo_CopiesCorrectly()
+    {
+        using var source = new ValueGridShape<int>(2, 2);
+        source.SetValue((0, 0), 1);
+        source.SetValue((1, 1), 2);
+
+        using var dest = new ValueGridShape<int>(2, 2);
+        source.CopyTo(dest);
+
+        Assert.AreEqual(1, dest.GetValue((0, 0)));
+        Assert.AreEqual(2, dest.GetValue((1, 1)));
+    }
+
+    [Test]
+    public void CopyTo_ThrowsOnDifferentDimensions()
+    {
+        using var source = new ValueGridShape<int>(2, 2);
+        using var dest = new ValueGridShape<int>(3, 3);
+
+        Assert.Throws<ArgumentException>(() => source.CopyTo(dest));
+    }
+
+    [Test]
+    public void CountValue_CountsCorrectly()
+    {
+        using var grid = new ValueGridShape<int>(3, 3);
+        grid.SetValue((0, 0), 5);
+        grid.SetValue((1, 1), 5);
+        grid.SetValue((2, 2), 10);
+
+        Assert.AreEqual(2, grid.CountValue(5));
+        Assert.AreEqual(1, grid.CountValue(10));
+        Assert.AreEqual(6, grid.CountValue(0));
+    }
+
+    [Test]
+    public void CountWhere_CountsWithPredicate()
+    {
+        using var grid = new ValueGridShape<int>(3, 3);
+        grid.SetValue((0, 0), 5);
+        grid.SetValue((1, 1), 10);
+        grid.SetValue((2, 2), 15);
+
+        Assert.AreEqual(2, grid.CountWhere(x => x > 5));
+        Assert.AreEqual(3, grid.CountWhere(x => x > 0));
+    }
+
+    [Test]
+    public void Any_DetectsMatchingElements()
+    {
+        using var grid = new ValueGridShape<int>(2, 2);
+        grid.SetValue((1, 1), 42);
+
+        Assert.IsTrue(grid.Any(x => x == 42));
+        Assert.IsFalse(grid.Any(x => x == 100));
+    }
+
+    [Test]
+    public void All_ChecksAllElements()
+    {
+        using var grid = new ValueGridShape<int>(2, 2, 5);
+
+        Assert.IsTrue(grid.All(x => x == 5));
+
+        grid.SetValue((0, 0), 10);
+        Assert.IsFalse(grid.All(x => x == 5));
+    }
+
+    [Test]
+    public void ToGridShape_ConvertsCorrectly()
+    {
+        using var valueGrid = new ValueGridShape<int>(3, 3);
+        valueGrid.SetValue((0, 0), 1);
+        valueGrid.SetValue((1, 1), 1);
+        valueGrid.SetValue((2, 2), 0);
+
+        using var gridShape = valueGrid.ToGridShape(1);
+
+        Assert.AreEqual(3, gridShape.Width);
+        Assert.AreEqual(3, gridShape.Height);
+        Assert.IsTrue(gridShape.GetCell((0, 0)));
+        Assert.IsTrue(gridShape.GetCell((1, 1)));
+        Assert.IsFalse(gridShape.GetCell((2, 2)));
+    }
+
+    [Test]
+    public void ToGridShape_WithPredicate_ConvertsCorrectly()
+    {
+        using var valueGrid = new ValueGridShape<int>(3, 3);
+        valueGrid.SetValue((0, 0), 5);
+        valueGrid.SetValue((1, 1), 10);
+        valueGrid.SetValue((2, 2), 3);
+
+        using var gridShape = valueGrid.ToGridShape(x => x > 5);
+
+        Assert.IsFalse(gridShape.GetCell((0, 0)));
+        Assert.IsTrue(gridShape.GetCell((1, 1)));
+        Assert.IsFalse(gridShape.GetCell((2, 2)));
+    }
+
+    [Test]
+    public void FromGridShape_ConvertsCorrectly()
+    {
+        using var gridShape = Shapes.LShape();
+        using var valueGrid = new ValueGridShape<int>(2, 2);
+
+        valueGrid.FromGridShape(gridShape, 1, 0);
+
+        Assert.AreEqual(1, valueGrid.GetValue((0, 0)));
+        Assert.AreEqual(1, valueGrid.GetValue((0, 1)));
+        Assert.AreEqual(1, valueGrid.GetValue((1, 1)));
+        Assert.AreEqual(0, valueGrid.GetValue((1, 0)));
+    }
+
+    [Test]
+    public void AsReadOnly_ReturnsReadOnlyView()
+    {
+        using var grid = new ValueGridShape<int>(2, 2);
+        grid.SetValue((1, 1), 42);
+
+        var readOnly = grid.AsReadOnly();
+
+        Assert.AreEqual(2, readOnly.Width);
+        Assert.AreEqual(2, readOnly.Height);
+        Assert.AreEqual(42, readOnly.GetValue((1, 1)));
+        Assert.AreEqual(0, readOnly.GetValue((0, 0)));
+    }
+}

--- a/Assets/Tests/Standard/ValueGridShapeTests.cs
+++ b/Assets/Tests/Standard/ValueGridShapeTests.cs
@@ -7,7 +7,7 @@ public class StandardValueGridShapeTests
     [Test]
     public void Constructor_CreatesEmptyGrid()
     {
-        using var grid = new ValueGridShape<int>(3, 4);
+        var grid = new ValueGridShape<int>(3, 4);
 
         Assert.AreEqual(3, grid.Width);
         Assert.AreEqual(4, grid.Height);
@@ -21,7 +21,7 @@ public class StandardValueGridShapeTests
     [Test]
     public void Constructor_WithDefaultValue_FillsGrid()
     {
-        using var grid = new ValueGridShape<int>(3, 3, 42);
+        var grid = new ValueGridShape<int>(3, 3, 42);
 
         for (int y = 0; y < 3; y++)
         for (int x = 0; x < 3; x++)
@@ -31,7 +31,7 @@ public class StandardValueGridShapeTests
     [Test]
     public void SetValue_GetValue_WorkCorrectly()
     {
-        using var grid = new ValueGridShape<string>(2, 2);
+        var grid = new ValueGridShape<string>(2, 2);
 
         grid.SetValue((0, 0), "A");
         grid.SetValue((1, 1), "B");
@@ -44,7 +44,7 @@ public class StandardValueGridShapeTests
     [Test]
     public void Indexer_WorksCorrectly()
     {
-        using var grid = new ValueGridShape<int>(3, 3);
+        var grid = new ValueGridShape<int>(3, 3);
 
         grid[1, 1] = 5;
         grid[(2, 2)] = 10;
@@ -57,7 +57,7 @@ public class StandardValueGridShapeTests
     [Test]
     public void Fill_FillsAllCells()
     {
-        using var grid = new ValueGridShape<int>(3, 3);
+        var grid = new ValueGridShape<int>(3, 3);
 
         grid.Fill(7);
 
@@ -69,7 +69,7 @@ public class StandardValueGridShapeTests
     [Test]
     public void FillRect_FillsRectangleArea()
     {
-        using var grid = new ValueGridShape<int>(5, 5);
+        var grid = new ValueGridShape<int>(5, 5);
 
         grid.FillRect(1, 1, 3, 2, 99);
 
@@ -84,7 +84,7 @@ public class StandardValueGridShapeTests
     [Test]
     public void Clear_ResetsToDefault()
     {
-        using var grid = new ValueGridShape<int>(3, 3);
+        var grid = new ValueGridShape<int>(3, 3);
         grid.Fill(5);
 
         grid.Clear();
@@ -97,7 +97,7 @@ public class StandardValueGridShapeTests
     [Test]
     public void Contains_DetectsBounds()
     {
-        using var grid = new ValueGridShape<int>(3, 3);
+        var grid = new ValueGridShape<int>(3, 3);
 
         Assert.IsTrue(grid.Contains((0, 0)));
         Assert.IsTrue(grid.Contains((2, 2)));
@@ -150,7 +150,7 @@ public class StandardValueGridShapeTests
     [Test]
     public void CountValue_CountsCorrectly()
     {
-        using var grid = new ValueGridShape<int>(3, 3);
+        var grid = new ValueGridShape<int>(3, 3);
         grid.SetValue((0, 0), 5);
         grid.SetValue((1, 1), 5);
         grid.SetValue((2, 2), 10);
@@ -163,7 +163,7 @@ public class StandardValueGridShapeTests
     [Test]
     public void CountWhere_CountsWithPredicate()
     {
-        using var grid = new ValueGridShape<int>(3, 3);
+        var grid = new ValueGridShape<int>(3, 3);
         grid.SetValue((0, 0), 5);
         grid.SetValue((1, 1), 10);
         grid.SetValue((2, 2), 15);
@@ -175,7 +175,7 @@ public class StandardValueGridShapeTests
     [Test]
     public void Any_DetectsMatchingElements()
     {
-        using var grid = new ValueGridShape<int>(2, 2);
+        var grid = new ValueGridShape<int>(2, 2);
         grid.SetValue((1, 1), 42);
 
         Assert.IsTrue(grid.Any(x => x == 42));
@@ -185,7 +185,7 @@ public class StandardValueGridShapeTests
     [Test]
     public void All_ChecksAllElements()
     {
-        using var grid = new ValueGridShape<int>(2, 2, 5);
+        var grid = new ValueGridShape<int>(2, 2, 5);
 
         Assert.IsTrue(grid.All(x => x == 5));
 
@@ -201,7 +201,7 @@ public class StandardValueGridShapeTests
         valueGrid.SetValue((1, 1), 1);
         valueGrid.SetValue((2, 2), 0);
 
-        using var gridShape = valueGrid.ToGridShape(1);
+        var gridShape = valueGrid.ToGridShape(1);
 
         Assert.AreEqual(3, gridShape.Width);
         Assert.AreEqual(3, gridShape.Height);
@@ -218,7 +218,7 @@ public class StandardValueGridShapeTests
         valueGrid.SetValue((1, 1), 10);
         valueGrid.SetValue((2, 2), 3);
 
-        using var gridShape = valueGrid.ToGridShape(x => x > 5);
+        var gridShape = valueGrid.ToGridShape(x => x > 5);
 
         Assert.IsFalse(gridShape.GetCell((0, 0)));
         Assert.IsTrue(gridShape.GetCell((1, 1)));
@@ -228,7 +228,7 @@ public class StandardValueGridShapeTests
     [Test]
     public void FromGridShape_ConvertsCorrectly()
     {
-        using var gridShape = Shapes.LShape();
+        var gridShape = Shapes.LShape();
         using var valueGrid = new ValueGridShape<int>(2, 2);
 
         valueGrid.FromGridShape(gridShape, 1, 0);
@@ -242,7 +242,7 @@ public class StandardValueGridShapeTests
     [Test]
     public void AsReadOnly_ReturnsReadOnlyView()
     {
-        using var grid = new ValueGridShape<int>(2, 2);
+        var grid = new ValueGridShape<int>(2, 2);
         grid.SetValue((1, 1), 42);
 
         var readOnly = grid.AsReadOnly();

--- a/Assets/Tests/Standard/ValueGridShapeTests.cs
+++ b/Assets/Tests/Standard/ValueGridShapeTests.cs
@@ -7,7 +7,7 @@ public class StandardValueGridShapeTests
     [Test]
     public void Constructor_CreatesEmptyGrid()
     {
-        using using var grid = new ValueGridShape<int>(3, 4);
+        using var grid = new ValueGridShape<int>(3, 4);
 
         Assert.AreEqual(3, grid.Width);
         Assert.AreEqual(4, grid.Height);
@@ -44,7 +44,7 @@ public class StandardValueGridShapeTests
     [Test]
     public void Indexer_WorksCorrectly()
     {
-        using var grid = new ValueGridShape<int>(3, 3);
+        var grid = new ValueGridShape<int>(3, 3);
 
         grid[1, 1] = 5;
         grid[(2, 2)] = 10;
@@ -52,6 +52,8 @@ public class StandardValueGridShapeTests
         Assert.AreEqual(5, grid[1, 1]);
         Assert.AreEqual(10, grid[(2, 2)]);
         Assert.AreEqual(0, grid[0, 0]);
+
+        grid.Dispose();
     }
 
     [Test]

--- a/Assets/Tests/Standard/ValueGridShapeTests.cs.meta
+++ b/Assets/Tests/Standard/ValueGridShapeTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d1b4cb60eb81f434e92af6480e249c1c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Tests.asmdef
+++ b/Assets/Tests/Tests.asmdef
@@ -8,7 +8,8 @@
         "GUID:0acc523941302664db1f4e527237feb3",
         "GUID:c011ecb9120a34eb5974a5da73072824",
         "GUID:04eb7e0343b59421cb3393dad67dcdc4",
-        "GUID:68d21117fae84fb89e2c50a258aa4fdc"
+        "GUID:68d21117fae84fb89e2c50a258aa4fdc",
+        "GUID:a9c4e76a0725d4c6da711e4ffcb096cd"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Packages/com.fullmetalbagel.dope-grid/Runtime/Core/DropGrid.Core.asmdef
+++ b/Packages/com.fullmetalbagel.dope-grid/Runtime/Core/DropGrid.Core.asmdef
@@ -1,3 +1,22 @@
 {
-	"name": "DropGrid.Core"
+    "name": "DropGrid.Core",
+    "rootNamespace": "",
+    "references": [
+        "GUID:d8b63aba1907145bea998dd612889d6b"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.mathematics",
+            "expression": "1.0.0",
+            "define": "UNITY_MATHEMATICS"
+        }
+    ],
+    "noEngineReferences": false
 }

--- a/Packages/com.fullmetalbagel.dope-grid/Runtime/Core/GridPosition.cs
+++ b/Packages/com.fullmetalbagel.dope-grid/Runtime/Core/GridPosition.cs
@@ -2,6 +2,7 @@ namespace DopeGrid;
 
 public readonly record struct GridPosition(int X, int Y)
 {
+    public static readonly GridPosition Zero = new(0, 0);
     public int X { get; } = X;
     public int Y { get; } = Y;
 

--- a/Packages/com.fullmetalbagel.dope-grid/Runtime/Core/GridPosition.cs
+++ b/Packages/com.fullmetalbagel.dope-grid/Runtime/Core/GridPosition.cs
@@ -1,0 +1,23 @@
+namespace DopeGrid;
+
+public readonly record struct GridPosition(int X, int Y)
+{
+    public int X { get; } = X;
+    public int Y { get; } = Y;
+
+    public static implicit operator (int x, int y)(GridPosition pos) => (pos.X, pos.Y);
+    public static implicit operator GridPosition((int x, int y) tuple) => new(tuple.x, tuple.y);
+
+#if UNITY_MATHEMATICS
+    public static implicit operator Unity.Mathematics.int2(GridPosition pos) => new(pos.X, pos.Y);
+    public static implicit operator GridPosition(Unity.Mathematics.int2 value) => new(value.x, value.y);
+#endif
+
+    public void Deconstruct(out int x, out int y)
+    {
+        x = X;
+        y = Y;
+    }
+
+    public override string ToString() => $"({X}, {Y})";
+}

--- a/Packages/com.fullmetalbagel.dope-grid/Runtime/Core/GridPosition.cs.meta
+++ b/Packages/com.fullmetalbagel.dope-grid/Runtime/Core/GridPosition.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6679457d50081405b979e6ee9eba93ea
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.fullmetalbagel.dope-grid/Runtime/Native/GridBoard.cs
+++ b/Packages/com.fullmetalbagel.dope-grid/Runtime/Native/GridBoard.cs
@@ -1,6 +1,5 @@
 using System;
 using Unity.Collections;
-using Unity.Mathematics;
 
 namespace DopeGrid.Native;
 
@@ -46,11 +45,6 @@ public struct GridBoard : IDisposable
         return _grid.GetCell(pos);
     }
 
-    public bool IsCellOccupied(int2 pos)
-    {
-        return _grid.GetCell(pos);
-    }
-
     public bool TryAddItem(ImmutableGridShape item)
     {
         var pos = _grid.FindFirstFit(item);
@@ -74,29 +68,11 @@ public struct GridBoard : IDisposable
         return false;
     }
 
-    public bool TryAddItemAt(ImmutableGridShape shape, int2 pos)
-    {
-        if (_grid.CanPlaceItem(shape, pos))
-        {
-            AddItemAt(shape, pos);
-            return true;
-        }
-
-        return false;
-    }
-
     private void AddItemAt(ImmutableGridShape shape, GridPosition pos)
     {
         _grid.PlaceItem(shape, pos);
         _items.Add(shape);
         _itemPositions.Add(pos);
-    }
-
-    private void AddItemAt(ImmutableGridShape shape, int2 pos)
-    {
-        _grid.PlaceItem(shape, pos);
-        _items.Add(shape);
-        _itemPositions.Add((GridPosition)pos);
     }
 
     public void RemoveItem(int index)

--- a/Packages/com.fullmetalbagel.dope-grid/Runtime/Native/GridBoardExtension.cs
+++ b/Packages/com.fullmetalbagel.dope-grid/Runtime/Native/GridBoardExtension.cs
@@ -76,35 +76,6 @@ public static class GridBoardExtension
         return true;
     }
 
-    [Pure, MustUseReturnValue]
-    public static bool CanPlaceItem(this GridShape container, in GridShape.ReadOnly item, int2 pos)
-    {
-        return container.AsReadOnly().CanPlaceItem(item, pos);
-    }
-
-    [Pure, MustUseReturnValue]
-    public static bool CanPlaceItem(this in GridShape.ReadOnly container, in GridShape.ReadOnly item, int2 pos)
-    {
-        // Bounds check
-        if (pos.x < 0 || pos.y < 0 || pos.x + item.Width > container.Width || pos.y + item.Height > container.Height)
-            return false;
-
-        // Check each bit of the shape against the grid
-        for (var sy = 0; sy < item.Height; sy++)
-        for (var sx = 0; sx < item.Width; sx++)
-        {
-            var shapePos = new int2(sx, sy);
-            if (item.GetCell(shapePos))
-            {
-                var gridPos = new int2(pos.x + sx, pos.y + sy);
-                if (container.GetCell(gridPos))
-                    return false;
-            }
-        }
-
-        return true;
-    }
-
     public static void PlaceItem(this GridShape container, in GridShape.ReadOnly item, GridPosition pos)
     {
         for (var sy = 0; sy < item.Height; sy++)
@@ -119,20 +90,6 @@ public static class GridBoardExtension
         }
     }
 
-    public static void PlaceItem(this GridShape container, in GridShape.ReadOnly item, int2 pos)
-    {
-        for (var sy = 0; sy < item.Height; sy++)
-        for (var sx = 0; sx < item.Width; sx++)
-        {
-            var shapePos = new int2(sx, sy);
-            if (item.GetCell(shapePos))
-            {
-                var gridPos = new int2(pos.x + sx, pos.y + sy);
-                container.SetCell(gridPos, true);
-            }
-        }
-    }
-
     public static void RemoveItem(this GridShape container, in GridShape.ReadOnly item, GridPosition pos)
     {
         for (var sy = 0; sy < item.Height; sy++)
@@ -142,20 +99,6 @@ public static class GridBoardExtension
             if (item.GetCell(shapePos))
             {
                 var gridPos = new GridPosition(pos.X + sx, pos.Y + sy);
-                container.SetCell(gridPos, false);
-            }
-        }
-    }
-
-    public static void RemoveItem(this GridShape container, in GridShape.ReadOnly item, int2 pos)
-    {
-        for (var sy = 0; sy < item.Height; sy++)
-        for (var sx = 0; sx < item.Width; sx++)
-        {
-            var shapePos = new int2(sx, sy);
-            if (item.GetCell(shapePos))
-            {
-                var gridPos = new int2(pos.x + sx, pos.y + sy);
                 container.SetCell(gridPos, false);
             }
         }

--- a/Packages/com.fullmetalbagel.dope-grid/Runtime/Native/GridBoardExtension.cs
+++ b/Packages/com.fullmetalbagel.dope-grid/Runtime/Native/GridBoardExtension.cs
@@ -1,6 +1,5 @@
 using JetBrains.Annotations;
 using Unity.Collections;
-using Unity.Mathematics;
 
 namespace DopeGrid.Native;
 
@@ -24,26 +23,6 @@ public static class GridBoardExtension
                 return new GridPosition(x, y);
 
         return new GridPosition(-1, -1);
-    }
-
-    [Pure, MustUseReturnValue]
-    public static int2 FindFirstFitInt2(this GridShape container, in GridShape.ReadOnly item)
-    {
-        return container.AsReadOnly().FindFirstFitInt2(item);
-    }
-
-    [Pure, MustUseReturnValue]
-    public static int2 FindFirstFitInt2(this in GridShape.ReadOnly container, in GridShape.ReadOnly item)
-    {
-        var maxY = container.Height - item.Height + 1;
-        var maxX = container.Width - item.Width + 1;
-
-        for (var y = 0; y < maxY; y++)
-        for (var x = 0; x < maxX; x++)
-            if (container.CanPlaceItem(item, new int2(x, y)))
-                return new int2(x, y);
-
-        return new int2(-1, -1);
     }
 
     public static int PlaceMultipleShapes(

--- a/Packages/com.fullmetalbagel.dope-grid/Runtime/Native/GridShape.cs
+++ b/Packages/com.fullmetalbagel.dope-grid/Runtime/Native/GridShape.cs
@@ -2,7 +2,6 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using Unity.Collections;
 using Unity.Jobs;
-using Unity.Mathematics;
 
 namespace DopeGrid.Native;
 
@@ -30,15 +29,12 @@ public struct GridShape : IEquatable<GridShape>, INativeDisposable
     }
 
     public readonly int GetIndex(GridPosition pos) => GetIndex(pos.X, pos.Y);
-    public readonly int GetIndex(int2 pos) => GetIndex(pos.x, pos.y);
     public readonly int GetIndex(int x, int y) => y * Width + x;
 
     public readonly bool GetCell(GridPosition pos) => GetCell(pos.X, pos.Y);
-    public readonly bool GetCell(int2 pos) => GetCell(pos.x, pos.y);
     public readonly bool GetCell(int x, int y) => ReadOnlyBits.Get(GetIndex(x, y));
 
     public void SetCell(GridPosition pos, bool value) => SetCell(pos.X, pos.Y, value);
-    public void SetCell(int2 pos, bool value) => SetCell(pos.x, pos.y, value);
     public void SetCell(int x, int y, bool value) => Bits.Set(GetIndex(x, y), value);
 
     public bool this[int x, int y]
@@ -48,12 +44,6 @@ public struct GridShape : IEquatable<GridShape>, INativeDisposable
     }
 
     public bool this[GridPosition pos]
-    {
-        readonly get => GetCell(pos);
-        set => SetCell(pos, value);
-    }
-
-    public bool this[int2 pos]
     {
         readonly get => GetCell(pos);
         set => SetCell(pos, value);
@@ -82,14 +72,9 @@ public struct GridShape : IEquatable<GridShape>, INativeDisposable
         return this;
     }
 
-    public GridShape FillRect(GridPosition pos, int2 size, bool value = true)
+    public GridShape FillRect(GridPosition pos, int width, int height, bool value = true)
     {
-        return FillRect(pos.X, pos.Y, size.x, size.y, value);
-    }
-
-    public GridShape FillRect(int2 pos, int2 size, bool value = true)
-    {
-        return FillRect(pos.x, pos.y, size.x, size.y, value);
+        return FillRect(pos.X, pos.Y, width, height, value);
     }
 
     public void Clear()
@@ -132,7 +117,6 @@ public struct GridShape : IEquatable<GridShape>, INativeDisposable
     {
         public int Width { get; }
         public int Height { get; }
-        public int2 Bound => new(Width, Height);
         public ReadOnlySpanBitArray Bits { get; }
 
         public int Size => Width * Height;
@@ -146,17 +130,10 @@ public struct GridShape : IEquatable<GridShape>, INativeDisposable
             Bits = bits;
         }
 
-        internal ReadOnly(int2 bound, ReadOnlySpanBitArray bits)
-            : this(bound.x, bound.y, bits)
-        {
-        }
-
         public int GetIndex(GridPosition pos) => GetIndex(pos.X, pos.Y);
-        public int GetIndex(int2 pos) => GetIndex(pos.x, pos.y);
         public int GetIndex(int x, int y) => y * Width + x;
 
         public bool GetCell(GridPosition pos) => GetCell(pos.X, pos.Y);
-        public bool GetCell(int2 pos) => GetCell(pos.x, pos.y);
         public bool GetCell(int x, int y) => Bits.Get(GetIndex(x, y));
 
         public GridShape Clone(Allocator allocator)

--- a/Packages/com.fullmetalbagel.dope-grid/Runtime/Native/GridShape.cs
+++ b/Packages/com.fullmetalbagel.dope-grid/Runtime/Native/GridShape.cs
@@ -29,12 +29,15 @@ public struct GridShape : IEquatable<GridShape>, INativeDisposable
         _bits = new NativeArray<byte>(SpanBitArrayUtility.ByteCount(bitLength), allocator, NativeArrayOptions.ClearMemory);
     }
 
+    public readonly int GetIndex(GridPosition pos) => GetIndex(pos.X, pos.Y);
     public readonly int GetIndex(int2 pos) => GetIndex(pos.x, pos.y);
     public readonly int GetIndex(int x, int y) => y * Width + x;
 
+    public readonly bool GetCell(GridPosition pos) => GetCell(pos.X, pos.Y);
     public readonly bool GetCell(int2 pos) => GetCell(pos.x, pos.y);
     public readonly bool GetCell(int x, int y) => ReadOnlyBits.Get(GetIndex(x, y));
 
+    public void SetCell(GridPosition pos, bool value) => SetCell(pos.X, pos.Y, value);
     public void SetCell(int2 pos, bool value) => SetCell(pos.x, pos.y, value);
     public void SetCell(int x, int y, bool value) => Bits.Set(GetIndex(x, y), value);
 
@@ -42,6 +45,12 @@ public struct GridShape : IEquatable<GridShape>, INativeDisposable
     {
         readonly get => GetCell(x, y);
         set => SetCell(x, y, value);
+    }
+
+    public bool this[GridPosition pos]
+    {
+        readonly get => GetCell(pos);
+        set => SetCell(pos, value);
     }
 
     public bool this[int2 pos]
@@ -71,6 +80,11 @@ public struct GridShape : IEquatable<GridShape>, INativeDisposable
             }
         }
         return this;
+    }
+
+    public GridShape FillRect(GridPosition pos, int2 size, bool value = true)
+    {
+        return FillRect(pos.X, pos.Y, size.x, size.y, value);
     }
 
     public GridShape FillRect(int2 pos, int2 size, bool value = true)
@@ -137,9 +151,11 @@ public struct GridShape : IEquatable<GridShape>, INativeDisposable
         {
         }
 
+        public int GetIndex(GridPosition pos) => GetIndex(pos.X, pos.Y);
         public int GetIndex(int2 pos) => GetIndex(pos.x, pos.y);
         public int GetIndex(int x, int y) => y * Width + x;
 
+        public bool GetCell(GridPosition pos) => GetCell(pos.X, pos.Y);
         public bool GetCell(int2 pos) => GetCell(pos.x, pos.y);
         public bool GetCell(int x, int y) => Bits.Get(GetIndex(x, y));
 

--- a/Packages/com.fullmetalbagel.dope-grid/Runtime/Native/ImmutableGridShape.cs
+++ b/Packages/com.fullmetalbagel.dope-grid/Runtime/Native/ImmutableGridShape.cs
@@ -28,9 +28,11 @@ public readonly record struct ImmutableGridShape(int Id)
     public ImmutableGridShape Rotate90(Allocator allocator = Allocator.Temp) => new(Shapes.GetOrCreateRotated90(Id, allocator));
     public ImmutableGridShape Flip(Allocator allocator = Allocator.Temp) => new(Shapes.GetOrCreateFlipped(Id, allocator));
 
+    public int GetIndex(GridPosition pos) => GetIndex(pos.X, pos.Y);
     public int GetIndex(int2 pos) => GetIndex(pos.x, pos.y);
     public int GetIndex(int x, int y) => y * Width + x;
 
+    public bool GetCell(GridPosition pos) => GetCell(pos.X, pos.Y);
     public bool GetCell(int2 pos) => GetCell(pos.x, pos.y);
     public bool GetCell(int x, int y) => Pattern.Get(GetIndex(x, y));
 

--- a/Packages/com.fullmetalbagel.dope-grid/Runtime/Native/ValueGridShape.cs
+++ b/Packages/com.fullmetalbagel.dope-grid/Runtime/Native/ValueGridShape.cs
@@ -32,12 +32,15 @@ public struct ValueGridShape<T> : IEquatable<ValueGridShape<T>>, INativeDisposab
         Fill(defaultValue);
     }
 
+    public readonly int GetIndex(GridPosition pos) => GetIndex(pos.X, pos.Y);
     public readonly int GetIndex(int2 pos) => GetIndex(pos.x, pos.y);
     public readonly int GetIndex(int x, int y) => y * Width + x;
 
+    public readonly T GetValue(GridPosition pos) => GetValue(pos.X, pos.Y);
     public readonly T GetValue(int2 pos) => GetValue(pos.x, pos.y);
     public readonly T GetValue(int x, int y) => _values[GetIndex(x, y)];
 
+    public void SetValue(GridPosition pos, T value) => SetValue(pos.X, pos.Y, value);
     public void SetValue(int2 pos, T value) => SetValue(pos.x, pos.y, value);
     public void SetValue(int x, int y, T value) => _values[GetIndex(x, y)] = value;
 
@@ -45,6 +48,12 @@ public struct ValueGridShape<T> : IEquatable<ValueGridShape<T>>, INativeDisposab
     {
         readonly get => GetValue(x, y);
         set => SetValue(x, y, value);
+    }
+
+    public T this[GridPosition pos]
+    {
+        readonly get => GetValue(pos);
+        set => SetValue(pos, value);
     }
 
     public T this[int2 pos]
@@ -77,6 +86,11 @@ public struct ValueGridShape<T> : IEquatable<ValueGridShape<T>>, INativeDisposab
         }
     }
 
+    public void FillRect(GridPosition pos, int2 size, T value)
+    {
+        FillRect(pos.X, pos.Y, size.x, size.y, value);
+    }
+
     public void FillRect(int2 pos, int2 size, T value)
     {
         FillRect(pos.x, pos.y, size.x, size.y, value);
@@ -87,6 +101,7 @@ public struct ValueGridShape<T> : IEquatable<ValueGridShape<T>>, INativeDisposab
         Fill(default);
     }
 
+    public readonly bool Contains(GridPosition pos) => Contains(pos.X, pos.Y);
     public readonly bool Contains(int2 pos) => Contains(pos.x, pos.y);
     public readonly bool Contains(int x, int y) => x >= 0 && x < Width && y >= 0 && y < Height;
 
@@ -162,15 +177,19 @@ public struct ValueGridShape<T> : IEquatable<ValueGridShape<T>>, INativeDisposab
             Values = values;
         }
 
+        public int GetIndex(GridPosition pos) => GetIndex(pos.X, pos.Y);
         public int GetIndex(int2 pos) => GetIndex(pos.x, pos.y);
         public int GetIndex(int x, int y) => y * Width + x;
 
+        public T GetValue(GridPosition pos) => GetValue(pos.X, pos.Y);
         public T GetValue(int2 pos) => GetValue(pos.x, pos.y);
         public T GetValue(int x, int y) => Values[GetIndex(x, y)];
 
         public T this[int x, int y] => GetValue(x, y);
+        public T this[GridPosition pos] => GetValue(pos);
         public T this[int2 pos] => GetValue(pos);
 
+        public bool Contains(GridPosition pos) => Contains(pos.X, pos.Y);
         public bool Contains(int2 pos) => Contains(pos.x, pos.y);
         public bool Contains(int x, int y) => x >= 0 && x < Width && y >= 0 && y < Height;
 

--- a/Packages/com.fullmetalbagel.dope-grid/Runtime/Native/ValueGridShape.cs
+++ b/Packages/com.fullmetalbagel.dope-grid/Runtime/Native/ValueGridShape.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Unity.Collections;
 using Unity.Jobs;
-using Unity.Mathematics;
 
 namespace DopeGrid.Native;
 
@@ -33,15 +32,12 @@ public struct ValueGridShape<T> : IEquatable<ValueGridShape<T>>, INativeDisposab
     }
 
     public readonly int GetIndex(GridPosition pos) => GetIndex(pos.X, pos.Y);
-    public readonly int GetIndex(int2 pos) => GetIndex(pos.x, pos.y);
     public readonly int GetIndex(int x, int y) => y * Width + x;
 
     public readonly T GetValue(GridPosition pos) => GetValue(pos.X, pos.Y);
-    public readonly T GetValue(int2 pos) => GetValue(pos.x, pos.y);
     public readonly T GetValue(int x, int y) => _values[GetIndex(x, y)];
 
     public void SetValue(GridPosition pos, T value) => SetValue(pos.X, pos.Y, value);
-    public void SetValue(int2 pos, T value) => SetValue(pos.x, pos.y, value);
     public void SetValue(int x, int y, T value) => _values[GetIndex(x, y)] = value;
 
     public T this[int x, int y]
@@ -51,12 +47,6 @@ public struct ValueGridShape<T> : IEquatable<ValueGridShape<T>>, INativeDisposab
     }
 
     public T this[GridPosition pos]
-    {
-        readonly get => GetValue(pos);
-        set => SetValue(pos, value);
-    }
-
-    public T this[int2 pos]
     {
         readonly get => GetValue(pos);
         set => SetValue(pos, value);
@@ -86,14 +76,9 @@ public struct ValueGridShape<T> : IEquatable<ValueGridShape<T>>, INativeDisposab
         }
     }
 
-    public void FillRect(GridPosition pos, int2 size, T value)
+    public void FillRect(GridPosition pos, int width, int height, T value)
     {
-        FillRect(pos.X, pos.Y, size.x, size.y, value);
-    }
-
-    public void FillRect(int2 pos, int2 size, T value)
-    {
-        FillRect(pos.x, pos.y, size.x, size.y, value);
+        FillRect(pos.X, pos.Y, width, height, value);
     }
 
     public void Clear()
@@ -102,7 +87,6 @@ public struct ValueGridShape<T> : IEquatable<ValueGridShape<T>>, INativeDisposab
     }
 
     public readonly bool Contains(GridPosition pos) => Contains(pos.X, pos.Y);
-    public readonly bool Contains(int2 pos) => Contains(pos.x, pos.y);
     public readonly bool Contains(int x, int y) => x >= 0 && x < Width && y >= 0 && y < Height;
 
     public readonly ValueGridShape<T> Clone(Allocator allocator) => ((ReadOnly)this).Clone(allocator);
@@ -178,19 +162,15 @@ public struct ValueGridShape<T> : IEquatable<ValueGridShape<T>>, INativeDisposab
         }
 
         public int GetIndex(GridPosition pos) => GetIndex(pos.X, pos.Y);
-        public int GetIndex(int2 pos) => GetIndex(pos.x, pos.y);
         public int GetIndex(int x, int y) => y * Width + x;
 
         public T GetValue(GridPosition pos) => GetValue(pos.X, pos.Y);
-        public T GetValue(int2 pos) => GetValue(pos.x, pos.y);
         public T GetValue(int x, int y) => Values[GetIndex(x, y)];
 
         public T this[int x, int y] => GetValue(x, y);
         public T this[GridPosition pos] => GetValue(pos);
-        public T this[int2 pos] => GetValue(pos);
 
         public bool Contains(GridPosition pos) => Contains(pos.X, pos.Y);
-        public bool Contains(int2 pos) => Contains(pos.x, pos.y);
         public bool Contains(int x, int y) => x >= 0 && x < Width && y >= 0 && y < Height;
 
         public ValueGridShape<T> Clone(Allocator allocator)

--- a/Packages/com.fullmetalbagel.dope-grid/Runtime/Standard/GridBoard.cs
+++ b/Packages/com.fullmetalbagel.dope-grid/Runtime/Standard/GridBoard.cs
@@ -111,11 +111,9 @@ public struct GridBoard : IDisposable
 
     public GridBoard Clone()
     {
-        var clone = new GridBoard(Width, Height)
-        {
-            _initializedGrid = InitializedGrid.Clone(),
-            _grid = _grid.Clone()
-        };
+        var clone = new GridBoard(Width, Height);
+        _grid.CopyTo(clone._grid);
+        _initializedGrid.CopyTo(clone._initializedGrid);
         clone._items.AddRange(_items);
         clone._itemPositions.AddRange(_itemPositions);
         return clone;

--- a/Packages/com.fullmetalbagel.dope-grid/Runtime/Standard/GridBoard.cs
+++ b/Packages/com.fullmetalbagel.dope-grid/Runtime/Standard/GridBoard.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Collections.Generic;
+
+namespace DopeGrid.Standard;
+
+public sealed class GridBoard : IDisposable
+{
+    private GridShape _grid;
+    public GridShape.ReadOnly CurrentGrid => _grid;
+
+    private GridShape _initializedGrid;
+    public GridShape.ReadOnly InitializedGrid => _initializedGrid;
+
+    private readonly List<ImmutableGridShape> _items = new();
+    public IReadOnlyList<ImmutableGridShape> Items => _items;
+
+    private readonly List<(int x, int y)> _itemPositions = new();
+    public IReadOnlyList<(int x, int y)> ItemPositions => _itemPositions;
+
+    public int Width => _initializedGrid.Width;
+    public int Height => _initializedGrid.Height;
+
+    public GridBoard(int width, int height)
+    {
+        _grid = new GridShape(width, height);
+        _initializedGrid = _grid.Clone();
+    }
+
+    public GridBoard(GridShape containerShape)
+    {
+        if (containerShape.IsEmpty) throw new ArgumentException(nameof(containerShape));
+        _grid = containerShape.Clone();
+        _initializedGrid = _grid.Clone();
+    }
+
+    public int ItemCount => _items.Count;
+    public int FreeSpace => _grid.FreeSpaceCount;
+
+    public bool IsCellOccupied((int x, int y) pos)
+    {
+        return _grid.GetCell(pos);
+    }
+
+    public bool TryAddItem(ImmutableGridShape item)
+    {
+        var pos = _grid.FindFirstFit(item);
+        if (pos.x >= 0)
+        {
+            AddItemAt(item, pos);
+            return true;
+        }
+
+        return false;
+    }
+
+    public bool TryAddItemAt(ImmutableGridShape shape, (int x, int y) pos)
+    {
+        if (_grid.CanPlaceItem(shape, pos))
+        {
+            AddItemAt(shape, pos);
+            return true;
+        }
+
+        return false;
+    }
+
+    private void AddItemAt(ImmutableGridShape shape, (int x, int y) pos)
+    {
+        _grid.PlaceItem(shape, pos);
+        _items.Add(shape);
+        _itemPositions.Add(pos);
+    }
+
+    public void RemoveItem(int index)
+    {
+        if (index >= 0 && index < _items.Count)
+        {
+            var shape = _items[index];
+            var pos = _itemPositions[index];
+            _grid.RemoveItem(shape, pos);
+
+            // Swap with last element for O(1) removal
+            var lastIndex = _items.Count - 1;
+            if (index != lastIndex)
+            {
+                _items[index] = _items[lastIndex];
+                _itemPositions[index] = _itemPositions[lastIndex];
+            }
+            _items.RemoveAt(lastIndex);
+            _itemPositions.RemoveAt(lastIndex);
+        }
+    }
+
+    public void Clear()
+    {
+        InitializedGrid.CopyTo(_grid);
+        _items.Clear();
+        _itemPositions.Clear();
+    }
+
+    public void Dispose()
+    {
+        _initializedGrid.Dispose();
+        _grid.Dispose();
+    }
+
+    public GridBoard Clone()
+    {
+        var clone = new GridBoard(Width, Height)
+        {
+            _initializedGrid = InitializedGrid.Clone(),
+            _grid = _grid.Clone()
+        };
+        clone._items.AddRange(_items);
+        clone._itemPositions.AddRange(_itemPositions);
+        return clone;
+    }
+}

--- a/Packages/com.fullmetalbagel.dope-grid/Runtime/Standard/GridBoard.cs
+++ b/Packages/com.fullmetalbagel.dope-grid/Runtime/Standard/GridBoard.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace DopeGrid.Standard;
 
-public sealed class GridBoard : IDisposable
+public struct GridBoard : IDisposable
 {
     private GridShape _grid;
     public GridShape.ReadOnly CurrentGrid => _grid;
@@ -11,19 +11,25 @@ public sealed class GridBoard : IDisposable
     private GridShape _initializedGrid;
     public GridShape.ReadOnly InitializedGrid => _initializedGrid;
 
-    private readonly List<ImmutableGridShape> _items = new();
+    private readonly List<ImmutableGridShape> _items;
     public IReadOnlyList<ImmutableGridShape> Items => _items;
 
-    private readonly List<(int x, int y)> _itemPositions = new();
+    private readonly List<(int x, int y)> _itemPositions;
     public IReadOnlyList<(int x, int y)> ItemPositions => _itemPositions;
 
     public int Width => _initializedGrid.Width;
     public int Height => _initializedGrid.Height;
 
+    public int ItemCount => _items.Count;
+    public int FreeSpace => _grid.FreeSpaceCount;
+    public bool IsCreated => _grid.IsCreated;
+
     public GridBoard(int width, int height)
     {
         _grid = new GridShape(width, height);
         _initializedGrid = _grid.Clone();
+        _items = new();
+        _itemPositions = new();
     }
 
     public GridBoard(GridShape containerShape)
@@ -31,10 +37,9 @@ public sealed class GridBoard : IDisposable
         if (containerShape.IsEmpty) throw new ArgumentException(nameof(containerShape));
         _grid = containerShape.Clone();
         _initializedGrid = _grid.Clone();
+        _items = new();
+        _itemPositions = new();
     }
-
-    public int ItemCount => _items.Count;
-    public int FreeSpace => _grid.FreeSpaceCount;
 
     public bool IsCellOccupied((int x, int y) pos)
     {

--- a/Packages/com.fullmetalbagel.dope-grid/Runtime/Standard/GridBoard.cs
+++ b/Packages/com.fullmetalbagel.dope-grid/Runtime/Standard/GridBoard.cs
@@ -14,8 +14,8 @@ public struct GridBoard : IDisposable
     private readonly List<ImmutableGridShape> _items;
     public IReadOnlyList<ImmutableGridShape> Items => _items;
 
-    private readonly List<(int x, int y)> _itemPositions;
-    public IReadOnlyList<(int x, int y)> ItemPositions => _itemPositions;
+    private readonly List<GridPosition> _itemPositions;
+    public IReadOnlyList<GridPosition> ItemPositions => _itemPositions;
 
     public int Width => _initializedGrid.Width;
     public int Height => _initializedGrid.Height;
@@ -41,7 +41,7 @@ public struct GridBoard : IDisposable
         _itemPositions = new();
     }
 
-    public bool IsCellOccupied((int x, int y) pos)
+    public bool IsCellOccupied(GridPosition pos)
     {
         return _grid.GetCell(pos);
     }
@@ -49,7 +49,7 @@ public struct GridBoard : IDisposable
     public bool TryAddItem(ImmutableGridShape item)
     {
         var pos = _grid.FindFirstFit(item);
-        if (pos.x >= 0)
+        if (pos.X >= 0)
         {
             AddItemAt(item, pos);
             return true;
@@ -58,7 +58,7 @@ public struct GridBoard : IDisposable
         return false;
     }
 
-    public bool TryAddItemAt(ImmutableGridShape shape, (int x, int y) pos)
+    public bool TryAddItemAt(ImmutableGridShape shape, GridPosition pos)
     {
         if (_grid.CanPlaceItem(shape, pos))
         {
@@ -69,7 +69,7 @@ public struct GridBoard : IDisposable
         return false;
     }
 
-    private void AddItemAt(ImmutableGridShape shape, (int x, int y) pos)
+    private void AddItemAt(ImmutableGridShape shape, GridPosition pos)
     {
         _grid.PlaceItem(shape, pos);
         _items.Add(shape);

--- a/Packages/com.fullmetalbagel.dope-grid/Runtime/Standard/GridBoard.cs.meta
+++ b/Packages/com.fullmetalbagel.dope-grid/Runtime/Standard/GridBoard.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d8918f40de29c43c3ad94d589c22efd5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.fullmetalbagel.dope-grid/Runtime/Standard/GridBoardExtension.cs
+++ b/Packages/com.fullmetalbagel.dope-grid/Runtime/Standard/GridBoardExtension.cs
@@ -5,29 +5,29 @@ namespace DopeGrid.Standard;
 public static class GridBoardExtension
 {
     [Pure, MustUseReturnValue]
-    public static (int x, int y) FindFirstFit(this GridShape container, in GridShape.ReadOnly item)
+    public static GridPosition FindFirstFit(this GridShape container, in GridShape.ReadOnly item)
     {
         return container.AsReadOnly().FindFirstFit(item);
     }
 
     [Pure, MustUseReturnValue]
-    public static (int x, int y) FindFirstFit(this in GridShape.ReadOnly container, in GridShape.ReadOnly item)
+    public static GridPosition FindFirstFit(this in GridShape.ReadOnly container, in GridShape.ReadOnly item)
     {
         var maxY = container.Height - item.Height + 1;
         var maxX = container.Width - item.Width + 1;
 
         for (var y = 0; y < maxY; y++)
         for (var x = 0; x < maxX; x++)
-            if (container.CanPlaceItem(item, (x, y)))
-                return (x, y);
+            if (container.CanPlaceItem(item, new GridPosition(x, y)))
+                return new GridPosition(x, y);
 
-        return (-1, -1);
+        return new GridPosition(-1, -1);
     }
 
     public static int PlaceMultipleShapes(
         this GridShape container,
         GridShape[] items,
-        (int x, int y)[] outPositions)
+        GridPosition[] outPositions)
     {
         var placed = 0;
 
@@ -35,7 +35,7 @@ public static class GridBoardExtension
         for (var i = 0; i < items.Length; i++)
         {
             var pos = readonlyContainer.FindFirstFit(items[i]);
-            if (pos.x >= 0)
+            if (pos.X >= 0)
             {
                 container.PlaceItem(items[i], pos);
                 outPositions[placed] = pos;
@@ -47,26 +47,26 @@ public static class GridBoardExtension
     }
 
     [Pure, MustUseReturnValue]
-    public static bool CanPlaceItem(this GridShape container, in GridShape.ReadOnly item, (int x, int y) pos)
+    public static bool CanPlaceItem(this GridShape container, in GridShape.ReadOnly item, GridPosition pos)
     {
         return container.AsReadOnly().CanPlaceItem(item, pos);
     }
 
     [Pure, MustUseReturnValue]
-    public static bool CanPlaceItem(this in GridShape.ReadOnly container, in GridShape.ReadOnly item, (int x, int y) pos)
+    public static bool CanPlaceItem(this in GridShape.ReadOnly container, in GridShape.ReadOnly item, GridPosition pos)
     {
         // Bounds check
-        if (pos.x < 0 || pos.y < 0 || pos.x + item.Width > container.Width || pos.y + item.Height > container.Height)
+        if (pos.X < 0 || pos.Y < 0 || pos.X + item.Width > container.Width || pos.Y + item.Height > container.Height)
             return false;
 
         // Check each bit of the shape against the grid
         for (var sy = 0; sy < item.Height; sy++)
         for (var sx = 0; sx < item.Width; sx++)
         {
-            var shapePos = (sx, sy);
+            var shapePos = new GridPosition(sx, sy);
             if (item.GetCell(shapePos))
             {
-                var gridPos = (pos.x + sx, pos.y + sy);
+                var gridPos = new GridPosition(pos.X + sx, pos.Y + sy);
                 if (container.GetCell(gridPos))
                     return false;
             }
@@ -75,29 +75,29 @@ public static class GridBoardExtension
         return true;
     }
 
-    public static void PlaceItem(this GridShape container, in GridShape.ReadOnly item, (int x, int y) pos)
+    public static void PlaceItem(this GridShape container, in GridShape.ReadOnly item, GridPosition pos)
     {
         for (var sy = 0; sy < item.Height; sy++)
         for (var sx = 0; sx < item.Width; sx++)
         {
-            var shapePos = (sx, sy);
+            var shapePos = new GridPosition(sx, sy);
             if (item.GetCell(shapePos))
             {
-                var gridPos = (pos.x + sx, pos.y + sy);
+                var gridPos = new GridPosition(pos.X + sx, pos.Y + sy);
                 container.SetCell(gridPos, true);
             }
         }
     }
 
-    public static void RemoveItem(this GridShape container, in GridShape.ReadOnly item, (int x, int y) pos)
+    public static void RemoveItem(this GridShape container, in GridShape.ReadOnly item, GridPosition pos)
     {
         for (var sy = 0; sy < item.Height; sy++)
         for (var sx = 0; sx < item.Width; sx++)
         {
-            var shapePos = (sx, sy);
+            var shapePos = new GridPosition(sx, sy);
             if (item.GetCell(shapePos))
             {
-                var gridPos = (pos.x + sx, pos.y + sy);
+                var gridPos = new GridPosition(pos.X + sx, pos.Y + sy);
                 container.SetCell(gridPos, false);
             }
         }

--- a/Packages/com.fullmetalbagel.dope-grid/Runtime/Standard/GridBoardExtension.cs
+++ b/Packages/com.fullmetalbagel.dope-grid/Runtime/Standard/GridBoardExtension.cs
@@ -1,0 +1,105 @@
+using JetBrains.Annotations;
+
+namespace DopeGrid.Standard;
+
+public static class GridBoardExtension
+{
+    [Pure, MustUseReturnValue]
+    public static (int x, int y) FindFirstFit(this GridShape container, in GridShape.ReadOnly item)
+    {
+        return container.AsReadOnly().FindFirstFit(item);
+    }
+
+    [Pure, MustUseReturnValue]
+    public static (int x, int y) FindFirstFit(this in GridShape.ReadOnly container, in GridShape.ReadOnly item)
+    {
+        var maxY = container.Height - item.Height + 1;
+        var maxX = container.Width - item.Width + 1;
+
+        for (var y = 0; y < maxY; y++)
+        for (var x = 0; x < maxX; x++)
+            if (container.CanPlaceItem(item, (x, y)))
+                return (x, y);
+
+        return (-1, -1);
+    }
+
+    public static int PlaceMultipleShapes(
+        this GridShape container,
+        GridShape[] items,
+        (int x, int y)[] outPositions)
+    {
+        var placed = 0;
+
+        var readonlyContainer = container.AsReadOnly();
+        for (var i = 0; i < items.Length; i++)
+        {
+            var pos = readonlyContainer.FindFirstFit(items[i]);
+            if (pos.x >= 0)
+            {
+                container.PlaceItem(items[i], pos);
+                outPositions[placed] = pos;
+                placed++;
+            }
+        }
+
+        return placed;
+    }
+
+    [Pure, MustUseReturnValue]
+    public static bool CanPlaceItem(this GridShape container, in GridShape.ReadOnly item, (int x, int y) pos)
+    {
+        return container.AsReadOnly().CanPlaceItem(item, pos);
+    }
+
+    [Pure, MustUseReturnValue]
+    public static bool CanPlaceItem(this in GridShape.ReadOnly container, in GridShape.ReadOnly item, (int x, int y) pos)
+    {
+        // Bounds check
+        if (pos.x < 0 || pos.y < 0 || pos.x + item.Width > container.Width || pos.y + item.Height > container.Height)
+            return false;
+
+        // Check each bit of the shape against the grid
+        for (var sy = 0; sy < item.Height; sy++)
+        for (var sx = 0; sx < item.Width; sx++)
+        {
+            var shapePos = (sx, sy);
+            if (item.GetCell(shapePos))
+            {
+                var gridPos = (pos.x + sx, pos.y + sy);
+                if (container.GetCell(gridPos))
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    public static void PlaceItem(this GridShape container, in GridShape.ReadOnly item, (int x, int y) pos)
+    {
+        for (var sy = 0; sy < item.Height; sy++)
+        for (var sx = 0; sx < item.Width; sx++)
+        {
+            var shapePos = (sx, sy);
+            if (item.GetCell(shapePos))
+            {
+                var gridPos = (pos.x + sx, pos.y + sy);
+                container.SetCell(gridPos, true);
+            }
+        }
+    }
+
+    public static void RemoveItem(this GridShape container, in GridShape.ReadOnly item, (int x, int y) pos)
+    {
+        for (var sy = 0; sy < item.Height; sy++)
+        for (var sx = 0; sx < item.Width; sx++)
+        {
+            var shapePos = (sx, sy);
+            if (item.GetCell(shapePos))
+            {
+                var gridPos = (pos.x + sx, pos.y + sy);
+                container.SetCell(gridPos, false);
+            }
+        }
+    }
+}

--- a/Packages/com.fullmetalbagel.dope-grid/Runtime/Standard/GridBoardExtension.cs.meta
+++ b/Packages/com.fullmetalbagel.dope-grid/Runtime/Standard/GridBoardExtension.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 79646617fe15f41ada38051dc978e3de
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.fullmetalbagel.dope-grid/Runtime/Standard/GridShape.cs
+++ b/Packages/com.fullmetalbagel.dope-grid/Runtime/Standard/GridShape.cs
@@ -31,13 +31,13 @@ public struct GridShape : IEquatable<GridShape>, IDisposable
         Array.Clear(_bits, 0, _byteCount);
     }
 
-    public int GetIndex((int x, int y) pos) => GetIndex(pos.x, pos.y);
+    public int GetIndex(GridPosition pos) => GetIndex(pos.X, pos.Y);
     public int GetIndex(int x, int y) => y * Width + x;
 
-    public bool GetCell((int x, int y) pos) => GetCell(pos.x, pos.y);
+    public bool GetCell(GridPosition pos) => GetCell(pos.X, pos.Y);
     public bool GetCell(int x, int y) => ReadOnlyBits.Get(GetIndex(x, y));
 
-    public void SetCell((int x, int y) pos, bool value) => SetCell(pos.x, pos.y, value);
+    public void SetCell(GridPosition pos, bool value) => SetCell(pos.X, pos.Y, value);
     public void SetCell(int x, int y, bool value) => Bits.Set(GetIndex(x, y), value);
 
     public bool this[int x, int y]
@@ -46,7 +46,7 @@ public struct GridShape : IEquatable<GridShape>, IDisposable
         set => SetCell(x, y, value);
     }
 
-    public bool this[(int x, int y) pos]
+    public bool this[GridPosition pos]
     {
         get => GetCell(pos);
         set => SetCell(pos, value);
@@ -75,9 +75,9 @@ public struct GridShape : IEquatable<GridShape>, IDisposable
         return this;
     }
 
-    public GridShape FillRect((int x, int y) pos, (int width, int height) size, bool value = true)
+    public GridShape FillRect(GridPosition pos, (int width, int height) size, bool value = true)
     {
-        return FillRect(pos.x, pos.y, size.width, size.height, value);
+        return FillRect(pos.X, pos.Y, size.width, size.height, value);
     }
 
     public void Clear()
@@ -138,10 +138,10 @@ public struct GridShape : IEquatable<GridShape>, IDisposable
         {
         }
 
-        public int GetIndex((int x, int y) pos) => GetIndex(pos.x, pos.y);
+        public int GetIndex(GridPosition pos) => GetIndex(pos.X, pos.Y);
         public int GetIndex(int x, int y) => y * Width + x;
 
-        public bool GetCell((int x, int y) pos) => GetCell(pos.x, pos.y);
+        public bool GetCell(GridPosition pos) => GetCell(pos.X, pos.Y);
         public bool GetCell(int x, int y) => Bits.Get(GetIndex(x, y));
 
         public GridShape Clone()

--- a/Packages/com.fullmetalbagel.dope-grid/Runtime/Standard/GridShape.cs
+++ b/Packages/com.fullmetalbagel.dope-grid/Runtime/Standard/GridShape.cs
@@ -10,9 +10,9 @@ public struct GridShape : IEquatable<GridShape>, IDisposable
     public int Height { get; }
     public int Size => Width * Height;
 
-    public ReadOnlySpanBitArray ReadOnlyBits => new(_bits.AsSpan(0, _byteCount), Size);
-    internal SpanBitArray Bits => new(_bits.AsSpan(0, _byteCount), Size);
-    private byte[] _bits;
+    public ReadOnlySpanBitArray ReadOnlyBits => new(_bits!.AsSpan(0, _byteCount), Size);
+    internal SpanBitArray Bits => new(_bits!.AsSpan(0, _byteCount), Size);
+    private byte[]? _bits;
     private readonly int _byteCount;
 
     public int OccupiedSpaceCount => ReadOnlyBits.CountBits(0, Size);
@@ -90,7 +90,7 @@ public struct GridShape : IEquatable<GridShape>, IDisposable
         if (_bits != null)
         {
             ArrayPool<byte>.Shared.Return(_bits);
-            _bits = null!;
+            _bits = null;
         }
     }
 

--- a/Packages/com.fullmetalbagel.dope-grid/Runtime/Standard/GridShape.cs
+++ b/Packages/com.fullmetalbagel.dope-grid/Runtime/Standard/GridShape.cs
@@ -1,0 +1,169 @@
+using System;
+using System.Buffers;
+using System.Diagnostics.CodeAnalysis;
+
+namespace DopeGrid.Standard;
+
+public struct GridShape : IEquatable<GridShape>, IDisposable
+{
+    public int Width { get; }
+    public int Height { get; }
+    public int Size => Width * Height;
+
+    public ReadOnlySpanBitArray ReadOnlyBits => new(_bits.AsSpan(0, _byteCount), Size);
+    internal SpanBitArray Bits => new(_bits.AsSpan(0, _byteCount), Size);
+    private byte[] _bits;
+    private readonly int _byteCount;
+
+    public int OccupiedSpaceCount => ReadOnlyBits.CountBits(0, Size);
+    public int FreeSpaceCount => Size - OccupiedSpaceCount;
+    public bool IsEmpty => Width == 0 || Height == 0;
+    public bool IsCreated => _bits != null;
+
+    public GridShape(int width, int height)
+    {
+        Width = width;
+        Height = height;
+        var bitLength = width * height;
+        _byteCount = SpanBitArrayUtility.ByteCount(bitLength);
+
+        _bits = ArrayPool<byte>.Shared.Rent(_byteCount);
+        Array.Clear(_bits, 0, _byteCount);
+    }
+
+    public int GetIndex((int x, int y) pos) => GetIndex(pos.x, pos.y);
+    public int GetIndex(int x, int y) => y * Width + x;
+
+    public bool GetCell((int x, int y) pos) => GetCell(pos.x, pos.y);
+    public bool GetCell(int x, int y) => ReadOnlyBits.Get(GetIndex(x, y));
+
+    public void SetCell((int x, int y) pos, bool value) => SetCell(pos.x, pos.y, value);
+    public void SetCell(int x, int y, bool value) => Bits.Set(GetIndex(x, y), value);
+
+    public bool this[int x, int y]
+    {
+        get => GetCell(x, y);
+        set => SetCell(x, y, value);
+    }
+
+    public bool this[(int x, int y) pos]
+    {
+        get => GetCell(pos);
+        set => SetCell(pos, value);
+    }
+
+    public GridShape Fill(bool value)
+    {
+        Bits.SetAll(value);
+        return this;
+    }
+
+    public GridShape FillRect(int x, int y, int width, int height, bool value = true)
+    {
+        for (int dy = 0; dy < height; dy++)
+        {
+            for (int dx = 0; dx < width; dx++)
+            {
+                var px = x + dx;
+                var py = y + dy;
+                if (px >= 0 && px < Width && py >= 0 && py < Height)
+                {
+                    SetCell(px, py, value);
+                }
+            }
+        }
+        return this;
+    }
+
+    public GridShape FillRect((int x, int y) pos, (int width, int height) size, bool value = true)
+    {
+        return FillRect(pos.x, pos.y, size.width, size.height, value);
+    }
+
+    public void Clear()
+    {
+        Array.Clear(_bits, 0, _byteCount);
+    }
+
+    public void Dispose()
+    {
+        if (_bits != null)
+        {
+            ArrayPool<byte>.Shared.Return(_bits);
+            _bits = null!;
+        }
+    }
+
+    public GridShape Clone()
+    {
+        return AsReadOnly().Clone();
+    }
+
+    public void CopyTo(GridShape other)
+    {
+        AsReadOnly().CopyTo(other);
+    }
+
+    public static implicit operator ReadOnly(GridShape shape) => shape.AsReadOnly();
+    public ReadOnly AsReadOnly() => new(Width, Height, ReadOnlyBits);
+
+    public override int GetHashCode() => throw new NotSupportedException("GetHashCode() on GridShape and GridShape.ReadOnly is not supported.");
+    [SuppressMessage("Design", "CA1065:Do not raise exceptions in unexpected locations")]
+    public override bool Equals(object? obj) => throw new NotSupportedException("Equals(object) on GridShape and GridShape.ReadOnly is not supported.");
+    public bool Equals(GridShape other) => AsReadOnly().Equals(other.AsReadOnly());
+    public static bool operator ==(GridShape left, GridShape right) => left.Equals(right);
+    public static bool operator !=(GridShape left, GridShape right) => !(left == right);
+
+    [SuppressMessage("Design", "CA1716:Identifiers should not match keywords")]
+    public readonly ref struct ReadOnly
+    {
+        public int Width { get; }
+        public int Height { get; }
+        public (int width, int height) Bound => (Width, Height);
+        public ReadOnlySpanBitArray Bits { get; }
+
+        public int Size => Width * Height;
+        public int OccupiedSpaceCount => Bits.CountBits(0, Size);
+        public int FreeSpaceCount => Size - OccupiedSpaceCount;
+
+        internal ReadOnly(int width, int height, ReadOnlySpanBitArray bits)
+        {
+            Width = width;
+            Height = height;
+            Bits = bits;
+        }
+
+        internal ReadOnly((int width, int height) bound, ReadOnlySpanBitArray bits)
+            : this(bound.width, bound.height, bits)
+        {
+        }
+
+        public int GetIndex((int x, int y) pos) => GetIndex(pos.x, pos.y);
+        public int GetIndex(int x, int y) => y * Width + x;
+
+        public bool GetCell((int x, int y) pos) => GetCell(pos.x, pos.y);
+        public bool GetCell(int x, int y) => Bits.Get(GetIndex(x, y));
+
+        public GridShape Clone()
+        {
+            var clone = new GridShape(Width, Height);
+            CopyTo(clone);
+            return clone;
+        }
+
+        public void CopyTo(GridShape other)
+        {
+            if (Width != other.Width || Height != other.Height)
+                throw new ArgumentException($"Cannot copy to GridShape with different dimensions. Source: {Width}x{Height}, Target: {other.Width}x{other.Height}");
+
+            Bits.CopyTo(other.Bits);
+        }
+
+        public override int GetHashCode() => throw new NotSupportedException("GetHashCode() on GridShape and GridShape.ReadOnly is not supported.");
+        [SuppressMessage("Design", "CA1065:Do not raise exceptions in unexpected locations")]
+        public override bool Equals(object? obj) => throw new NotSupportedException("Equals(object) on GridShape and GridShape.ReadOnly is not supported.");
+        public bool Equals(ReadOnly other) => Width == other.Width && Height == other.Height && Bits.SequenceEqual(other.Bits);
+        public static bool operator ==(ReadOnly left, ReadOnly right) => left.Equals(right);
+        public static bool operator !=(ReadOnly left, ReadOnly right) => !left.Equals(right);
+    }
+}

--- a/Packages/com.fullmetalbagel.dope-grid/Runtime/Standard/GridShape.cs.meta
+++ b/Packages/com.fullmetalbagel.dope-grid/Runtime/Standard/GridShape.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 51f87979952ac403a93bb36bf68daa2c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.fullmetalbagel.dope-grid/Runtime/Standard/ImmutableGridShape.cs
+++ b/Packages/com.fullmetalbagel.dope-grid/Runtime/Standard/ImmutableGridShape.cs
@@ -22,10 +22,10 @@ public readonly record struct ImmutableGridShape(int Id)
     public ImmutableGridShape Rotate90() => new(Shapes.GetOrCreateRotated90(Id));
     public ImmutableGridShape Flip() => new(Shapes.GetOrCreateFlipped(Id));
 
-    public int GetIndex((int x, int y) pos) => GetIndex(pos.x, pos.y);
+    public int GetIndex(GridPosition pos) => GetIndex(pos.X, pos.Y);
     public int GetIndex(int x, int y) => y * Width + x;
 
-    public bool GetCell((int x, int y) pos) => GetCell(pos.x, pos.y);
+    public bool GetCell(GridPosition pos) => GetCell(pos.X, pos.Y);
     public bool GetCell(int x, int y) => Pattern.Get(GetIndex(x, y));
 
     public static implicit operator GridShape.ReadOnly(ImmutableGridShape shape) => shape.ToReadOnlyGridShape();

--- a/Packages/com.fullmetalbagel.dope-grid/Runtime/Standard/ImmutableGridShape.cs
+++ b/Packages/com.fullmetalbagel.dope-grid/Runtime/Standard/ImmutableGridShape.cs
@@ -108,7 +108,9 @@ internal class ImmutableGridShapeRepository
             if (bound.width != shape.Width || bound.height != shape.Height)
                 continue;
 
-            var pattern = GetPattern(i);
+            var patternBytes = _patterns[i];
+            var bitLength = bound.width * bound.height;
+            var pattern = new ReadOnlySpanBitArray(patternBytes.AsSpan(), bitLength);
             if (pattern.SequenceEqual(shape.Bits))
                 return i;
         }

--- a/Packages/com.fullmetalbagel.dope-grid/Runtime/Standard/ImmutableGridShape.cs
+++ b/Packages/com.fullmetalbagel.dope-grid/Runtime/Standard/ImmutableGridShape.cs
@@ -1,0 +1,174 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using JetBrains.Annotations;
+
+namespace DopeGrid.Standard;
+
+public readonly record struct ImmutableGridShape(int Id)
+{
+    private static ImmutableGridShapeRepository Shapes => ImmutableGridShapeRepository.Instance;
+    public static ImmutableGridShape Empty => new(0);
+
+    public int Id { get; } = Id;
+    public (int width, int height) Bound => Shapes.GetBound(Id);
+    public int Width => Bound.width;
+    public int Height => Bound.height;
+    public int Size => Width * Height;
+    public ReadOnlySpanBitArray Pattern => Shapes.GetPattern(Id);
+    public int OccupiedSpaceCount => Pattern.CountBits(0, Size);
+    public int FreeSpaceCount => Size - OccupiedSpaceCount;
+    public bool IsEmpty => Width == 0 || Height == 0;
+
+    public ImmutableGridShape Rotate90() => new(Shapes.GetOrCreateRotated90(Id));
+    public ImmutableGridShape Flip() => new(Shapes.GetOrCreateFlipped(Id));
+
+    public int GetIndex((int x, int y) pos) => GetIndex(pos.x, pos.y);
+    public int GetIndex(int x, int y) => y * Width + x;
+
+    public bool GetCell((int x, int y) pos) => GetCell(pos.x, pos.y);
+    public bool GetCell(int x, int y) => Pattern.Get(GetIndex(x, y));
+
+    public static implicit operator GridShape.ReadOnly(ImmutableGridShape shape) => shape.ToReadOnlyGridShape();
+    public GridShape.ReadOnly ToReadOnlyGridShape() => new(Width, Height, Pattern);
+
+    public void CopyTo(GridShape other)
+    {
+        ToReadOnlyGridShape().CopyTo(other);
+    }
+}
+
+public static class ImmutableGridShapeExtensions
+{
+    public static ImmutableGridShape GetOrCreateImmutable(this GridShape shape)
+    {
+        return shape.AsReadOnly().GetOrCreateImmutable();
+    }
+
+    public static ImmutableGridShape GetOrCreateImmutable(this in GridShape.ReadOnly shape)
+    {
+        if (!shape.IsTrimmed()) throw new ArgumentException("shape is not trimmed", nameof(shape));
+        return new ImmutableGridShape(ImmutableGridShapeRepository.Instance.GetOrCreateShape(shape));
+    }
+}
+
+internal class ImmutableGridShapeRepository
+{
+    private static readonly Lazy<ImmutableGridShapeRepository> _instance = new(() => new ImmutableGridShapeRepository());
+    public static ImmutableGridShapeRepository Instance => _instance.Value;
+
+    private readonly List<byte[]> _patterns = new() { Array.Empty<byte>() };
+    private readonly List<(int width, int height)> _bounds = new() { (0, 0) };
+    private readonly List<int> _rotate90Indices = new() { 0 };
+    private readonly List<int> _flipIndices = new() { 0 };
+    private readonly object _lock = new();
+
+    private ImmutableGridShapeRepository()
+    {
+    }
+
+    [Pure, MustUseReturnValue]
+    public (int width, int height) GetBound(int id)
+    {
+        lock (_lock)
+        {
+            return _bounds[id];
+        }
+    }
+
+    [Pure, MustUseReturnValue]
+    public ReadOnlySpanBitArray GetPattern(int id)
+    {
+        lock (_lock)
+        {
+            var pattern = _patterns[id];
+            var bound = _bounds[id];
+            var bitLength = bound.width * bound.height;
+            return new ReadOnlySpanBitArray(pattern.AsSpan(), bitLength);
+        }
+    }
+
+    [Pure, MustUseReturnValue]
+    public GridShape.ReadOnly GetReadOnlyShape(int id)
+    {
+        lock (_lock)
+        {
+            var bound = _bounds[id];
+            var pattern = GetPattern(id);
+            return new GridShape.ReadOnly(bound, pattern);
+        }
+    }
+
+    [Pure, MustUseReturnValue]
+    private int FindExistingShape(in GridShape.ReadOnly shape)
+    {
+        for (var i = 0; i < _bounds.Count; i++)
+        {
+            var bound = _bounds[i];
+            if (bound.width != shape.Width || bound.height != shape.Height)
+                continue;
+
+            var pattern = GetPattern(i);
+            if (pattern.SequenceEqual(shape.Bits))
+                return i;
+        }
+        return -1;
+    }
+
+    public int GetOrCreateShape(in GridShape.ReadOnly shape)
+    {
+        lock (_lock)
+        {
+            var id = FindExistingShape(shape);
+            if (id >= 0) return id;
+
+            id = _bounds.Count;
+
+            // Add bounds
+            _bounds.Add((shape.Width, shape.Height));
+
+            // Store pattern
+            var sizeInBytes = SpanBitArrayUtility.ByteCount(shape.Size);
+            var patternBytes = new byte[sizeInBytes];
+            shape.Bits.CopyTo(new SpanBitArray(patternBytes.AsSpan(), shape.Size));
+            _patterns.Add(patternBytes);
+
+            _rotate90Indices.Add(-1);
+            _flipIndices.Add(-1);
+            return id;
+        }
+    }
+
+    public int GetOrCreateRotated90(int id)
+    {
+        lock (_lock)
+        {
+            var rotatedId = _rotate90Indices[id];
+            if (rotatedId < 0)
+            {
+                var shape = GetReadOnlyShape(id);
+                using var rotatedShape = shape.Rotate(RotationDegree.Clockwise90);
+                rotatedId = GetOrCreateShape(rotatedShape);
+                _rotate90Indices[id] = rotatedId;
+            }
+            return rotatedId;
+        }
+    }
+
+    public int GetOrCreateFlipped(int id)
+    {
+        lock (_lock)
+        {
+            var flippedId = _flipIndices[id];
+            if (flippedId < 0)
+            {
+                var shape = GetReadOnlyShape(id);
+                using var flippedShape = shape.Flip(FlipAxis.Horizontal);
+                flippedId = GetOrCreateShape(flippedShape);
+                _flipIndices[id] = flippedId;
+                _flipIndices[flippedId] = id;
+            }
+            return flippedId;
+        }
+    }
+}

--- a/Packages/com.fullmetalbagel.dope-grid/Runtime/Standard/ImmutableGridShape.cs.meta
+++ b/Packages/com.fullmetalbagel.dope-grid/Runtime/Standard/ImmutableGridShape.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 527598c86909f408b8d8f9c4d46b1c2f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.fullmetalbagel.dope-grid/Runtime/Standard/Shapes.cs
+++ b/Packages/com.fullmetalbagel.dope-grid/Runtime/Standard/Shapes.cs
@@ -143,6 +143,12 @@ public static class Shapes
         var height = shape.Height;
         var newBound = GetRotatedDimensions(shape, degree);
 
+        if (degree == RotationDegree.None)
+        {
+            shape.Bits.CopyTo(output);
+            return shape;
+        }
+
         for (var y = 0; y < height; y++)
         {
             for (var x = 0; x < width; x++)

--- a/Packages/com.fullmetalbagel.dope-grid/Runtime/Standard/Shapes.cs
+++ b/Packages/com.fullmetalbagel.dope-grid/Runtime/Standard/Shapes.cs
@@ -1,0 +1,319 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using JetBrains.Annotations;
+
+namespace DopeGrid.Standard;
+
+public static class Shapes
+{
+    [SuppressMessage("Naming", "CA1720:Identifier contains type name")]
+    [Pure, MustUseReturnValue]
+    public static GridShape Single()
+    {
+        var shape = new GridShape(1, 1);
+        shape.SetCell((0, 0), true);
+        return shape;
+    }
+
+    [Pure, MustUseReturnValue]
+    public static GridShape Line(int length)
+    {
+        var shape = new GridShape(length, 1);
+        for (var i = 0; i < length; i++)
+            shape.SetCell((i, 0), true);
+        return shape;
+    }
+
+    [Pure, MustUseReturnValue]
+    public static GridShape Square(int size)
+    {
+        var shape = new GridShape(size, size);
+        for (var y = 0; y < size; y++)
+        for (var x = 0; x < size; x++)
+            shape.SetCell((x, y), true);
+        return shape;
+    }
+
+    [Pure, MustUseReturnValue]
+    public static GridShape LShape()
+    {
+        var shape = new GridShape(2, 2);
+        shape.SetCell((0, 0), true);
+        shape.SetCell((0, 1), true);
+        shape.SetCell((1, 1), true);
+        return shape;
+    }
+
+    [Pure, MustUseReturnValue]
+    public static GridShape TShape()
+    {
+        var shape = new GridShape(3, 2);
+        shape.SetCell((0, 0), true);
+        shape.SetCell((1, 0), true);
+        shape.SetCell((2, 0), true);
+        shape.SetCell((1, 1), true);
+        return shape;
+    }
+
+    [Pure, MustUseReturnValue]
+    public static GridShape Cross()
+    {
+        var shape = new GridShape(3, 3);
+        shape.SetCell((1, 0), true);
+        shape.SetCell((0, 1), true);
+        shape.SetCell((1, 1), true);
+        shape.SetCell((2, 1), true);
+        shape.SetCell((1, 2), true);
+        return shape;
+    }
+
+    // Immutable shape factory methods
+    [Pure, MustUseReturnValue]
+    public static ImmutableGridShape ImmutableSingle()
+    {
+        using var shape = Single();
+        return shape.GetOrCreateImmutable();
+    }
+
+    [Pure, MustUseReturnValue]
+    public static ImmutableGridShape ImmutableLine(int length)
+    {
+        using var shape = Line(length);
+        return shape.GetOrCreateImmutable();
+    }
+
+    [Pure, MustUseReturnValue]
+    public static ImmutableGridShape ImmutableSquare(int size)
+    {
+        using var shape = Square(size);
+        return shape.GetOrCreateImmutable();
+    }
+
+    [Pure, MustUseReturnValue]
+    public static ImmutableGridShape ImmutableLShape()
+    {
+        using var shape = LShape();
+        return shape.GetOrCreateImmutable();
+    }
+
+    [Pure, MustUseReturnValue]
+    public static ImmutableGridShape ImmutableTShape()
+    {
+        using var shape = TShape();
+        return shape.GetOrCreateImmutable();
+    }
+
+    [Pure, MustUseReturnValue]
+    public static ImmutableGridShape ImmutableCross()
+    {
+        using var shape = Cross();
+        return shape.GetOrCreateImmutable();
+    }
+
+    [Pure, MustUseReturnValue]
+    public static GridShape Rotate(this GridShape shape, RotationDegree degree)
+    {
+        return shape.AsReadOnly().Rotate(degree);
+    }
+
+    [Pure, MustUseReturnValue]
+    public static GridShape Rotate(this in GridShape.ReadOnly shape, RotationDegree degree)
+    {
+        var dimensions = shape.GetRotatedDimensions(degree);
+        var rotated = new GridShape(dimensions.width, dimensions.height);
+        shape.RotateBits(degree, rotated.Bits);
+        return rotated;
+    }
+
+    [Pure, MustUseReturnValue]
+    public static (int width, int height) GetRotatedDimensions(this in GridShape.ReadOnly shape, RotationDegree degree)
+    {
+        return degree switch
+        {
+            RotationDegree.Clockwise90 => (shape.Height, shape.Width),
+            RotationDegree.Clockwise180 => (shape.Width, shape.Height),
+            RotationDegree.Clockwise270 => (shape.Height, shape.Width),
+            _ => (shape.Width, shape.Height)
+        };
+    }
+
+    public static GridShape.ReadOnly RotateBits(this in GridShape.ReadOnly shape, RotationDegree degree, SpanBitArray output)
+    {
+        var width = shape.Width;
+        var height = shape.Height;
+        var newBound = GetRotatedDimensions(shape, degree);
+
+        for (var y = 0; y < height; y++)
+        {
+            for (var x = 0; x < width; x++)
+            {
+                if (!shape.GetCell((x, y))) continue;
+
+                (int x, int y) rotatedPos = degree switch
+                {
+                    RotationDegree.Clockwise90 => (height - 1 - y, x),
+                    RotationDegree.Clockwise180 => (width - 1 - x, height - 1 - y),
+                    RotationDegree.Clockwise270 => (y, width - 1 - x),
+                    _ => throw new ArgumentException($"Invalid rotation degree: {degree}")
+                };
+
+                var index = rotatedPos.y * newBound.width + rotatedPos.x;
+                output.Set(index, true);
+            }
+        }
+        return new GridShape.ReadOnly(newBound, output.AsReadOnly());
+    }
+
+    [Pure, MustUseReturnValue]
+    public static GridShape Flip(this GridShape shape, FlipAxis axis)
+    {
+        return shape.AsReadOnly().Flip(axis);
+    }
+
+    [Pure, MustUseReturnValue]
+    public static GridShape Flip(this in GridShape.ReadOnly shape, FlipAxis axis)
+    {
+        var flipped = new GridShape(shape.Width, shape.Height);
+        shape.FlipBits(axis, flipped.Bits);
+        return flipped;
+    }
+
+    public static GridShape.ReadOnly FlipBits(this in GridShape.ReadOnly shape, FlipAxis axis, SpanBitArray output)
+    {
+        var width = shape.Width;
+        var height = shape.Height;
+        var bits = shape.Bits;
+
+        for (var y = 0; y < height; y++)
+        {
+            var rowStart = y * width;
+
+            for (var x = 0; x < width; x++)
+            {
+                var sourceIndex = rowStart + x;
+                if (!bits.Get(sourceIndex)) continue;
+
+                var flippedPos = axis switch
+                {
+                    FlipAxis.Horizontal => (width - 1 - x, y),
+                    FlipAxis.Vertical => (x, height - 1 - y),
+                    _ => throw new ArgumentException($"Invalid flip axis: {axis}")
+                };
+
+                var destIndex = flippedPos.Item2 * width + flippedPos.Item1;
+                output.Set(destIndex, true);
+            }
+        }
+
+        return new GridShape.ReadOnly(width, height, output.AsReadOnly());
+    }
+
+    [Pure, MustUseReturnValue]
+    public static bool IsTrimmed(this GridShape shape)
+    {
+        return shape.AsReadOnly().IsTrimmed();
+    }
+
+    [Pure, MustUseReturnValue]
+    public static bool IsTrimmed(this in GridShape.ReadOnly shape)
+    {
+        if (shape.Width == 0 || shape.Height == 0)
+            return true;
+
+        return HasOccupiedCellInRow(shape, 0) &&
+               HasOccupiedCellInRow(shape, shape.Height - 1) &&
+               HasOccupiedCellInColumn(shape, 0) &&
+               HasOccupiedCellInColumn(shape, shape.Width - 1);
+
+        static bool HasOccupiedCellInRow(in GridShape.ReadOnly shape, int row)
+        {
+            var rowStart = row * shape.Width;
+            return shape.Bits.TestAny(rowStart, shape.Width);
+        }
+
+        static bool HasOccupiedCellInColumn(in GridShape.ReadOnly shape, int column)
+        {
+            for (var row = 0; row < shape.Height; row++)
+            {
+                if (shape.GetCell((column, row)))
+                    return true;
+            }
+            return false;
+        }
+    }
+
+    [Pure, MustUseReturnValue]
+    public static GridShape Trim(this in GridShape.ReadOnly shape)
+    {
+        if (shape.Width == 0 || shape.Height == 0)
+            return new GridShape(0, 0);
+
+        if (shape.IsTrimmed())
+            return shape.Clone();
+
+        var bits = shape.Bits;
+        var width = shape.Width;
+        var height = shape.Height;
+
+        var minY = -1;
+        var maxY = -1;
+
+        for (var y = 0; y < height; y++)
+        {
+            var rowStart = y * width;
+            if (bits.TestAny(rowStart, width))
+            {
+                if (minY == -1) minY = y;
+                maxY = y;
+            }
+        }
+
+        if (minY == -1)
+            return new GridShape(0, 0);
+
+        var minX = width;
+        var maxX = -1;
+
+        for (var y = minY; y <= maxY; y++)
+        {
+            for (var x = 0; x < width; x++)
+            {
+                if (shape.GetCell((x, y)))
+                {
+                    if (x < minX) minX = x;
+                    if (x > maxX) maxX = x;
+                }
+            }
+        }
+
+        var newWidth = maxX - minX + 1;
+        var newHeight = maxY - minY + 1;
+        var trimmed = new GridShape(newWidth, newHeight);
+
+        for (var row = 0; row < newHeight; row++)
+        {
+            for (var col = 0; col < newWidth; col++)
+            {
+                if (shape.GetCell((minX + col, minY + row)))
+                {
+                    trimmed.SetCell((col, row), true);
+                }
+            }
+        }
+
+        return trimmed;
+    }
+
+    [Pure, MustUseReturnValue]
+    public static ImmutableGridShape GetRotatedShape(this ImmutableGridShape shape, RotationDegree rotation)
+    {
+        return rotation switch
+        {
+            RotationDegree.None => shape,
+            RotationDegree.Clockwise90 => shape.Rotate90(),
+            RotationDegree.Clockwise180 => shape.Rotate90().Rotate90(),
+            RotationDegree.Clockwise270 => shape.Rotate90().Rotate90().Rotate90(),
+            _ => throw new ArgumentOutOfRangeException(nameof(rotation), rotation, null)
+        };
+    }
+}

--- a/Packages/com.fullmetalbagel.dope-grid/Runtime/Standard/Shapes.cs.meta
+++ b/Packages/com.fullmetalbagel.dope-grid/Runtime/Standard/Shapes.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f017c0373f5644e7f80da79019c85fc4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.fullmetalbagel.dope-grid/Runtime/Standard/ShapesValueGridExtension.cs
+++ b/Packages/com.fullmetalbagel.dope-grid/Runtime/Standard/ShapesValueGridExtension.cs
@@ -1,0 +1,62 @@
+using System;
+
+namespace DopeGrid.Standard;
+
+public static class ShapesValueGridExtension
+{
+    public static void FillShape<T>(this ValueGridShape<T> grid, ImmutableGridShape shape, (int x, int y) pos, T value)
+        where T : IEquatable<T>
+    {
+        // Check bounds to prevent out of range access
+        var maxX = Math.Min(shape.Width, grid.Width - pos.x);
+        var maxY = Math.Min(shape.Height, grid.Height - pos.y);
+        var startX = Math.Max(0, -pos.x);
+        var startY = Math.Max(0, -pos.y);
+
+        // Fill only the cells where the shape has true values
+        for (int y = startY; y < maxY; y++)
+        {
+            for (int x = startX; x < maxX; x++)
+            {
+                if (shape.GetCell((x, y)))
+                {
+                    var gridPos = (pos.x + x, pos.y + y);
+                    grid.SetValue(gridPos, value);
+                }
+            }
+        }
+    }
+
+    public static bool IsWithinBounds<T>(this in ValueGridShape<T>.ReadOnly grid, ImmutableGridShape shape, (int x, int y) position)
+        where T : IEquatable<T>
+    {
+        return position.x >= 0 && position.y >= 0 &&
+               position.x + shape.Width <= grid.Width &&
+               position.y + shape.Height <= grid.Height;
+    }
+
+    public static bool CheckShapeCells<T>(this in ValueGridShape<T>.ReadOnly grid, ImmutableGridShape shape, (int x, int y) position, Func<(int x, int y), T, bool> cellPredicate)
+        where T : IEquatable<T>
+    {
+        return grid.CheckShapeCells(shape, position, (pos, value, predicate) => predicate(pos, value), cellPredicate);
+    }
+
+    public static bool CheckShapeCells<T, TData>(this in ValueGridShape<T>.ReadOnly grid, ImmutableGridShape shape, (int x, int y) position, Func<(int x, int y), T, TData, bool> cellPredicate, TData data)
+        where T : IEquatable<T>
+    {
+        for (int y = 0; y < shape.Height; y++)
+        {
+            for (int x = 0; x < shape.Width; x++)
+            {
+                if (shape.GetCell((x, y)))
+                {
+                    var gridPos = (position.x + x, position.y + y);
+                    var cellValue = grid[gridPos];
+                    if (!cellPredicate(gridPos, cellValue, data))
+                        return false;
+                }
+            }
+        }
+        return true;
+    }
+}

--- a/Packages/com.fullmetalbagel.dope-grid/Runtime/Standard/ShapesValueGridExtension.cs.meta
+++ b/Packages/com.fullmetalbagel.dope-grid/Runtime/Standard/ShapesValueGridExtension.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 47e6215e6ee4848039efb1720f7ee39f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.fullmetalbagel.dope-grid/Runtime/Standard/ValueGridShape.cs
+++ b/Packages/com.fullmetalbagel.dope-grid/Runtime/Standard/ValueGridShape.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace DopeGrid.Standard;
 
-public class ValueGridShape<T> : IEquatable<ValueGridShape<T>>, IDisposable where T : IEquatable<T>
+public class ValueGridShape<T> : IEquatable<ValueGridShape<T>> where T : IEquatable<T>
 {
     public int Width { get; }
     public int Height { get; }
@@ -107,11 +107,6 @@ public class ValueGridShape<T> : IEquatable<ValueGridShape<T>>, IDisposable wher
     public int CountWhere(Func<T, bool> predicate) => AsReadOnly().CountWhere(predicate);
     public bool Any(Func<T, bool> predicate) => AsReadOnly().Any(predicate);
     public bool All(Func<T, bool> predicate) => AsReadOnly().All(predicate);
-
-    public void Dispose()
-    {
-        GC.SuppressFinalize(this);
-    }
 
     public bool Equals(ValueGridShape<T>? other)
     {

--- a/Packages/com.fullmetalbagel.dope-grid/Runtime/Standard/ValueGridShape.cs
+++ b/Packages/com.fullmetalbagel.dope-grid/Runtime/Standard/ValueGridShape.cs
@@ -32,13 +32,13 @@ public struct ValueGridShape<T> : IEquatable<ValueGridShape<T>>, IDisposable whe
         Array.Fill(_values, defaultValue, 0, width * height);
     }
 
-    public int GetIndex((int x, int y) pos) => GetIndex(pos.x, pos.y);
+    public int GetIndex(GridPosition pos) => GetIndex(pos.X, pos.Y);
     public int GetIndex(int x, int y) => y * Width + x;
 
-    public T GetValue((int x, int y) pos) => GetValue(pos.x, pos.y);
+    public T GetValue(GridPosition pos) => GetValue(pos.X, pos.Y);
     public T GetValue(int x, int y) => Values[GetIndex(x, y)];
 
-    public void SetValue((int x, int y) pos, T value) => SetValue(pos.x, pos.y, value);
+    public void SetValue(GridPosition pos, T value) => SetValue(pos.X, pos.Y, value);
     public void SetValue(int x, int y, T value) => Values[GetIndex(x, y)] = value;
 
     public T this[int x, int y]
@@ -47,7 +47,7 @@ public struct ValueGridShape<T> : IEquatable<ValueGridShape<T>>, IDisposable whe
         set => SetValue(x, y, value);
     }
 
-    public T this[(int x, int y) pos]
+    public T this[GridPosition pos]
     {
         get => GetValue(pos);
         set => SetValue(pos, value);
@@ -74,9 +74,9 @@ public struct ValueGridShape<T> : IEquatable<ValueGridShape<T>>, IDisposable whe
         }
     }
 
-    public void FillRect((int x, int y) pos, (int width, int height) size, T value)
+    public void FillRect(GridPosition pos, (int width, int height) size, T value)
     {
-        FillRect(pos.x, pos.y, size.width, size.height, value);
+        FillRect(pos.X, pos.Y, size.width, size.height, value);
     }
 
     public void Clear()
@@ -84,7 +84,7 @@ public struct ValueGridShape<T> : IEquatable<ValueGridShape<T>>, IDisposable whe
         Fill(default!);
     }
 
-    public bool Contains((int x, int y) pos) => Contains(pos.x, pos.y);
+    public bool Contains(GridPosition pos) => Contains(pos.X, pos.Y);
     public bool Contains(int x, int y) => x >= 0 && x < Width && y >= 0 && y < Height;
 
     public ValueGridShape<T> Clone() => AsReadOnly().Clone();
@@ -155,16 +155,16 @@ public struct ValueGridShape<T> : IEquatable<ValueGridShape<T>>, IDisposable whe
             _values = values;
         }
 
-        public int GetIndex((int x, int y) pos) => GetIndex(pos.x, pos.y);
+        public int GetIndex(GridPosition pos) => GetIndex(pos.X, pos.Y);
         public int GetIndex(int x, int y) => y * Width + x;
 
-        public T GetValue((int x, int y) pos) => GetValue(pos.x, pos.y);
+        public T GetValue(GridPosition pos) => GetValue(pos.X, pos.Y);
         public T GetValue(int x, int y) => _values[GetIndex(x, y)];
 
         public T this[int x, int y] => GetValue(x, y);
-        public T this[(int x, int y) pos] => GetValue(pos);
+        public T this[GridPosition pos] => GetValue(pos);
 
-        public bool Contains((int x, int y) pos) => Contains(pos.x, pos.y);
+        public bool Contains(GridPosition pos) => Contains(pos.X, pos.Y);
         public bool Contains(int x, int y) => x >= 0 && x < Width && y >= 0 && y < Height;
 
         public ValueGridShape<T> Clone()

--- a/Packages/com.fullmetalbagel.dope-grid/Runtime/Standard/ValueGridShape.cs
+++ b/Packages/com.fullmetalbagel.dope-grid/Runtime/Standard/ValueGridShape.cs
@@ -5,7 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace DopeGrid.Standard;
 
-public struct ValueGridShape<T> : IEquatable<ValueGridShape<T>>, IDisposable where T : unmanaged, IEquatable<T>
+public struct ValueGridShape<T> : IEquatable<ValueGridShape<T>>, IDisposable where T : IEquatable<T>
 {
     public int Width { get; }
     public int Height { get; }

--- a/Packages/com.fullmetalbagel.dope-grid/Runtime/Standard/ValueGridShape.cs
+++ b/Packages/com.fullmetalbagel.dope-grid/Runtime/Standard/ValueGridShape.cs
@@ -1,0 +1,265 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace DopeGrid.Standard;
+
+public class ValueGridShape<T> : IEquatable<ValueGridShape<T>>, IDisposable where T : IEquatable<T>
+{
+    public int Width { get; }
+    public int Height { get; }
+    public int Size => Width * Height;
+    public bool IsEmpty => Width == 0 || Height == 0;
+    private T[] _values;
+    public T[] Values => _values;
+
+    public ValueGridShape(int width, int height)
+    {
+        Width = width;
+        Height = height;
+        _values = new T[width * height];
+    }
+
+    public ValueGridShape(int width, int height, T defaultValue)
+    {
+        Width = width;
+        Height = height;
+        _values = new T[width * height];
+        Fill(defaultValue);
+    }
+
+    public int GetIndex((int x, int y) pos) => GetIndex(pos.x, pos.y);
+    public int GetIndex(int x, int y) => y * Width + x;
+
+    public T GetValue((int x, int y) pos) => GetValue(pos.x, pos.y);
+    public T GetValue(int x, int y) => _values[GetIndex(x, y)];
+
+    public void SetValue((int x, int y) pos, T value) => SetValue(pos.x, pos.y, value);
+    public void SetValue(int x, int y, T value) => _values[GetIndex(x, y)] = value;
+
+    public T this[int x, int y]
+    {
+        get => GetValue(x, y);
+        set => SetValue(x, y, value);
+    }
+
+    public T this[(int x, int y) pos]
+    {
+        get => GetValue(pos);
+        set => SetValue(pos, value);
+    }
+
+    public void Fill(T value)
+    {
+        Array.Fill(_values, value);
+    }
+
+    public void FillRect(int x, int y, int width, int height, T value)
+    {
+        for (int dy = 0; dy < height; dy++)
+        {
+            for (int dx = 0; dx < width; dx++)
+            {
+                var px = x + dx;
+                var py = y + dy;
+                if (px >= 0 && px < Width && py >= 0 && py < Height)
+                {
+                    SetValue(px, py, value);
+                }
+            }
+        }
+    }
+
+    public void FillRect((int x, int y) pos, (int width, int height) size, T value)
+    {
+        FillRect(pos.x, pos.y, size.width, size.height, value);
+    }
+
+    public void Clear()
+    {
+        Fill(default!);
+    }
+
+    public bool Contains((int x, int y) pos) => Contains(pos.x, pos.y);
+    public bool Contains(int x, int y) => x >= 0 && x < Width && y >= 0 && y < Height;
+
+    public ValueGridShape<T> Clone() => AsReadOnly().Clone();
+    public void CopyTo(ValueGridShape<T> other) => AsReadOnly().CopyTo(other);
+
+    public GridShape ToGridShape(T trueValue) => AsReadOnly().ToGridShape(trueValue);
+    public GridShape ToGridShape(Func<T, bool> predicate) => AsReadOnly().ToGridShape(predicate);
+
+    public void FromGridShape(GridShape shape, T trueValue, T falseValue)
+    {
+        if (Width != shape.Width || Height != shape.Height)
+            throw new ArgumentException($"Cannot copy from GridShape with different dimensions. Source: {shape.Width}x{shape.Height}, Target: {Width}x{Height}");
+
+        for (int y = 0; y < Height; y++)
+        {
+            for (int x = 0; x < Width; x++)
+            {
+                SetValue(x, y, shape.GetCell(x, y) ? trueValue : falseValue);
+            }
+        }
+    }
+
+    public int CountValue(T value) => AsReadOnly().CountValue(value);
+    public int CountWhere(Func<T, bool> predicate) => AsReadOnly().CountWhere(predicate);
+    public bool Any(Func<T, bool> predicate) => AsReadOnly().Any(predicate);
+    public bool All(Func<T, bool> predicate) => AsReadOnly().All(predicate);
+
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
+    }
+
+    public bool Equals(ValueGridShape<T>? other)
+    {
+        if (other == null || Width != other.Width || Height != other.Height)
+            return false;
+
+        return _values.AsSpan().SequenceEqual(other._values.AsSpan());
+    }
+
+    public override int GetHashCode() => throw new NotSupportedException("GetHashCode() on ValueGridShape is not supported.");
+    [SuppressMessage("Design", "CA1065:Do not raise exceptions in unexpected locations")]
+    public override bool Equals(object? obj) => throw new NotSupportedException("Equals(object) on ValueGridShape is not supported.");
+
+    public static bool operator ==(ValueGridShape<T>? left, ValueGridShape<T>? right) => left?.Equals(right) ?? right is null;
+    public static bool operator !=(ValueGridShape<T>? left, ValueGridShape<T>? right) => !(left == right);
+
+    public static implicit operator ReadOnly(ValueGridShape<T> value) => value.AsReadOnly();
+    public ReadOnly AsReadOnly() => new(Width, Height, _values);
+
+    [SuppressMessage("Design", "CA1716:Identifiers should not match keywords")]
+    public readonly ref struct ReadOnly
+    {
+        public int Width { get; }
+        public int Height { get; }
+        public int Size => Width * Height;
+        public bool IsEmpty => Width == 0 || Height == 0;
+        private readonly ReadOnlySpan<T> _values;
+
+        internal ReadOnly(int width, int height, ReadOnlySpan<T> values)
+        {
+            Width = width;
+            Height = height;
+            _values = values;
+        }
+
+        public int GetIndex((int x, int y) pos) => GetIndex(pos.x, pos.y);
+        public int GetIndex(int x, int y) => y * Width + x;
+
+        public T GetValue((int x, int y) pos) => GetValue(pos.x, pos.y);
+        public T GetValue(int x, int y) => _values[GetIndex(x, y)];
+
+        public T this[int x, int y] => GetValue(x, y);
+        public T this[(int x, int y) pos] => GetValue(pos);
+
+        public bool Contains((int x, int y) pos) => Contains(pos.x, pos.y);
+        public bool Contains(int x, int y) => x >= 0 && x < Width && y >= 0 && y < Height;
+
+        public ValueGridShape<T> Clone()
+        {
+            var clone = new ValueGridShape<T>(Width, Height);
+            CopyTo(clone);
+            return clone;
+        }
+
+        public void CopyTo(ValueGridShape<T> other)
+        {
+            if (Width != other.Width || Height != other.Height)
+                throw new ArgumentException($"Cannot copy to ValueGridShape<{typeof(T).Name}> with different dimensions. Source: {Width}x{Height}, Target: {other.Width}x{other.Height}");
+            _values.CopyTo(other._values.AsSpan());
+        }
+
+        public GridShape ToGridShape(T trueValue)
+        {
+            return ToGridShape((value, @true) => EqualityComparer<T>.Default.Equals(value, @true), trueValue);
+        }
+
+        public GridShape ToGridShape(Func<T, bool> predicate)
+        {
+            return ToGridShape((value, p) => p(value), predicate);
+        }
+
+        public GridShape ToGridShape<TCaptureData>(Func<T, TCaptureData, bool> predicate, TCaptureData data)
+        {
+            var shape = new GridShape(Width, Height);
+            for (int y = 0; y < Height; y++)
+            {
+                for (int x = 0; x < Width; x++)
+                {
+                    shape.SetCell(x, y, predicate(GetValue(x, y), data));
+                }
+            }
+            return shape;
+        }
+
+        public int CountValue(T target)
+        {
+            return Count((v, t) => EqualityComparer<T>.Default.Equals(v, t), target);
+        }
+
+        public int CountWhere(Func<T, bool> predicate)
+        {
+            return Count((value, p) => p(value), predicate);
+        }
+
+        public int Count<TCaptureData>(Func<T, TCaptureData, bool> predicate, TCaptureData data)
+        {
+            int count = 0;
+            for (int i = 0; i < _values.Length; i++)
+            {
+                if (predicate(_values[i], data))
+                    count++;
+            }
+            return count;
+        }
+
+        public bool Any(Func<T, bool> predicate)
+        {
+            return Any((v, p) => p(v), predicate);
+        }
+
+        public bool Any<TCaptureData>(Func<T, TCaptureData, bool> predicate, TCaptureData data)
+        {
+            foreach (var t in _values)
+            {
+                if (predicate(t, data))
+                    return true;
+            }
+            return false;
+        }
+
+        public bool All(Func<T, bool> predicate)
+        {
+            return All((v, p) => p(v), predicate);
+        }
+
+        public bool All<TCaptureData>(Func<T, TCaptureData, bool> predicate, TCaptureData data)
+        {
+            foreach (var t in _values)
+            {
+                if (!predicate(t, data))
+                    return false;
+            }
+            return true;
+        }
+
+        public bool Equals(ReadOnly other)
+        {
+            if (Width != other.Width || Height != other.Height)
+                return false;
+
+            return _values.SequenceEqual(other._values);
+        }
+
+        public override int GetHashCode() => throw new NotSupportedException("GetHashCode() on ValueGridShape.ReadOnly is not supported.");
+        [SuppressMessage("Design", "CA1065:Do not raise exceptions in unexpected locations")]
+        public override bool Equals(object? obj) => throw new NotSupportedException("Equals(object) on ValueGridShape.ReadOnly is not supported.");
+
+        public static bool operator ==(ReadOnly left, ReadOnly right) => left.Equals(right);
+        public static bool operator !=(ReadOnly left, ReadOnly right) => !left.Equals(right);
+    }
+}

--- a/Packages/com.fullmetalbagel.dope-grid/Runtime/Standard/ValueGridShape.cs.meta
+++ b/Packages/com.fullmetalbagel.dope-grid/Runtime/Standard/ValueGridShape.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 126c65a450ae74423b337c4571af127a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.fullmetalbagel.dope-grid/Runtime/Standard/csc.rsp
+++ b/Packages/com.fullmetalbagel.dope-grid/Runtime/Standard/csc.rsp
@@ -1,0 +1,3 @@
+﻿-nullable:enable
+-warnaserror
+-langVersion:10

--- a/Packages/com.fullmetalbagel.dope-grid/Runtime/Standard/csc.rsp.meta
+++ b/Packages/com.fullmetalbagel.dope-grid/Runtime/Standard/csc.rsp.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 7fc339f5a26114ad4a02f45d0dc25b83
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.fullmetalbagel.dope-inventory-ugui/Runtime/UI/DraggingItem.cs
+++ b/Packages/com.fullmetalbagel.dope-inventory-ugui/Runtime/UI/DraggingItem.cs
@@ -29,6 +29,7 @@ public class DraggingItem
 
     public int2 GetGridPosition(RectTransform transform, float2 cellSize)
     {
-        return transform.GetGridPosition(cellSize, Shape.Bound, View.position);
+        var (width, height) = Shape.Bound;
+        return transform.GetGridPosition(cellSize, width, height, View.position);
     }
 }

--- a/Packages/com.fullmetalbagel.dope-inventory-ugui/Runtime/UI/Extension.cs
+++ b/Packages/com.fullmetalbagel.dope-inventory-ugui/Runtime/UI/Extension.cs
@@ -8,14 +8,14 @@ namespace DopeGrid.Inventory;
 public static class Extension
 {
     [Pure, MustUseReturnValue]
-    public static int2 GetGridPosition(this RectTransform transform, float2 cellSize, int2 shapeSize, Vector2 worldPosition)
+    public static GridPosition GetGridPosition(this RectTransform transform, float2 cellSize, int shapeWidth, int shapeHeight, Vector2 worldPosition)
     {
         // Convert from Canvas coordinates (center pivot) to InventoryView coordinates (top-left pivot)
         var localPosInInventory = transform.InverseTransformPoint(worldPosition);
 
         // Account for the dragging ghost having center pivot - convert to top-left corner
         // The ghost position represents the center of the rotated item, but we need the top-left of the grid shape
-        var rotatedSize = new Vector2(shapeSize.x * cellSize.x, shapeSize.y * cellSize.y);
+        var rotatedSize = new Vector2(shapeWidth * cellSize.x, shapeHeight * cellSize.y);
         var topLeftPos = localPosInInventory - new Vector3(rotatedSize.x * 0.5f, -rotatedSize.y * 0.5f, 0f);
 
         // Convert to top-left origin from the inventory view's pivot

--- a/Packages/com.fullmetalbagel.dope-inventory-ugui/Runtime/UI/InventoryViewDragController.cs
+++ b/Packages/com.fullmetalbagel.dope-inventory-ugui/Runtime/UI/InventoryViewDragController.cs
@@ -147,6 +147,8 @@ internal sealed class InventoryViewDragController : IDisposable
     private void UpdateDraggingItemRotation()
     {
         if (_draggingItem == null) return;
-        _draggingItem.Rotation.ApplyToRectTransform(_draggingItem.View, (float2)_cellSize * _draggingItem.Shape.Bound);
+        var (width, height) = _draggingItem.Shape.Bound;
+        var size = new Vector2(_cellSize.x * width, _cellSize.y * height) ;
+        _draggingItem.Rotation.ApplyToRectTransform(_draggingItem.View, size);
     }
 }


### PR DESCRIPTION
## Summary
- Add pure C# standard implementation (DopeGrid.Standard) that runs on all platforms without Unity dependencies
- Implement GridShape, GridBoard, and ImmutableGridShape using standard C# collections
- Add comprehensive test coverage for standard implementation
- Fix failing standard implementation tests

## Test plan
- [x] All standard implementation tests pass (GridShapeTests, GridBoardTests, ImmutableGridShapeTests, GridBoardExtensionTests)
- [x] Verify tests run in Unity Test Runner
- [x] Confirm no Unity-specific dependencies in Standard assembly

🤖 Generated with [Claude Code](https://claude.com/claude-code)