### PR TITLE
fix: Apply rotation to shape in TryAutoPlaceItem

### DIFF
--- a/Packages/com.fullmetalbagel.dope-inventory-ugui/Runtime/Model/Inventory.cs
+++ b/Packages/com.fullmetalbagel.dope-inventory-ugui/Runtime/Model/Inventory.cs
@@ -61,7 +61,7 @@ public struct Inventory : INativeDisposable
         position = new(-1, -1);
         for (var rotation = RotationDegree.None; rotation <= RotationDegree.Clockwise270; rotation++)
         {
-            var shape = itemDefinition.Shape;
+            var shape = itemDefinition.Shape.GetRotatedShape(rotation);
             if (((ReadOnly)this).TryFindFirstFitPosition(shape, out position))
             {
                 var placedItem = new InventoryItem(id, itemDefinition, rotation, position);


### PR DESCRIPTION
## Summary
- Fix `TryAutoPlaceItem` to correctly apply rotation when testing for placement fit

## Problem
The `TryAutoPlaceItem` method was not applying the rotation to the shape before checking if it fits. It was always checking the base shape without rotation.

## Solution
Changed line 64 from:
```csharp
var shape = itemDefinition.Shape;
```

To:
```csharp
var shape = itemDefinition.Shape.GetRotatedShape(rotation);
```

Now the method correctly tests each rotation (0°, 90°, 180°, 270°) and finds the first one that fits.

## Test Plan
- [x] Existing tests should now work correctly with rotation variants
- [x] No compilation errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)