### PR TITLE
Add NuGet package publishing workflow

### DIFF
--- a/.github/NUGET_SETUP.md
+++ b/.github/NUGET_SETUP.md
@@ -1,0 +1,154 @@
+# NuGet Publishing Setup
+
+This guide explains how to set up and use the NuGet publishing workflow for DopeGrid.
+
+## Prerequisites
+
+1. **NuGet Account**: Create an account at https://www.nuget.org
+2. **API Key**: Generate an API key from your NuGet account settings
+   - Go to https://www.nuget.org/account/apikeys
+   - Click "Create" and give it a name (e.g., "DopeGrid GitHub Actions")
+   - Set the key scope to "Push" and select package glob pattern or specific package
+   - Copy the generated API key (you'll only see it once!)
+
+## GitHub Setup
+
+### Add NuGet API Key as Secret
+
+1. Go to your GitHub repository: https://github.com/Full-Metal-Bagel/dope-grid
+2. Navigate to **Settings** → **Secrets and variables** → **Actions**
+3. Click **New repository secret**
+4. Name: `NUGET_API_KEY`
+5. Value: Paste your NuGet API key
+6. Click **Add secret**
+
+## Publishing Methods
+
+### Method 1: Automatic Publishing on Release (Recommended)
+
+This is the recommended approach for production releases.
+
+1. Create and push a git tag with version:
+   ```bash
+   git tag v1.0.0
+   git push origin v1.0.0
+   ```
+
+2. Go to GitHub Releases: https://github.com/Full-Metal-Bagel/dope-grid/releases
+3. Click **Draft a new release**
+4. Choose the tag you just created (v1.0.0)
+5. Fill in release title and description
+6. Click **Publish release**
+7. The workflow will automatically:
+   - Extract version from tag (removes 'v' prefix)
+   - Run tests
+   - Build and pack the NuGet package
+   - Publish to NuGet.org
+
+### Method 2: Manual Publishing via Workflow Dispatch
+
+Use this for testing or manual releases.
+
+1. Go to **Actions** tab: https://github.com/Full-Metal-Bagel/dope-grid/actions
+2. Select **Publish to NuGet** workflow
+3. Click **Run workflow**
+4. Enter version number (e.g., `1.0.0-beta`)
+5. Click **Run workflow**
+
+## Version Management
+
+### Semantic Versioning
+
+Follow [SemVer](https://semver.org/) for version numbers:
+- **MAJOR.MINOR.PATCH** (e.g., 1.0.0)
+- **MAJOR**: Breaking changes
+- **MINOR**: New features (backward compatible)
+- **PATCH**: Bug fixes (backward compatible)
+
+### Pre-release Versions
+
+For beta/alpha releases, append a suffix:
+- `1.0.0-alpha.1`
+- `1.0.0-beta.1`
+- `1.0.0-rc.1`
+
+## Workflow Details
+
+The workflow performs these steps:
+
+1. **Checkout**: Clones the repository
+2. **Setup .NET**: Installs .NET 8.0 SDK
+3. **Extract Version**: Gets version from tag or manual input
+4. **Update csproj**: Injects version into DopeGrid.csproj
+5. **Restore**: Restores NuGet dependencies
+6. **Build**: Builds in Release configuration
+7. **Test**: Runs all tests to ensure quality
+8. **Pack**: Creates .nupkg and .snupkg (symbols) files
+9. **Publish**: Pushes packages to NuGet.org
+10. **Upload Artifacts**: Saves packages as GitHub artifacts (for debugging)
+
+## Package Contents
+
+The published NuGet package includes:
+
+- **DopeGrid.dll**: Main library (netstandard2.1)
+- **DopeGrid.pdb**: Debug symbols (in separate .snupkg)
+- **README.md**: Project documentation
+- **Dependencies**: JetBrains.Annotations 2025.2.2
+
+## Testing the Package Locally
+
+Before publishing, you can test the package locally:
+
+```bash
+# Build and pack locally
+cd dotnet/DopeGrid
+dotnet pack --configuration Release --output ./local-nupkg
+
+# Test in another project
+cd /path/to/test/project
+dotnet add package DopeGrid --source /path/to/dope-grid/dotnet/DopeGrid/local-nupkg
+```
+
+## Troubleshooting
+
+### "Package already exists" Error
+
+If you see `409 Conflict - The package already exists`, either:
+- Increment the version number
+- The workflow uses `--skip-duplicate` to ignore this error
+
+### Tests Failing
+
+The workflow will abort if tests fail. Fix tests before publishing:
+```bash
+cd dotnet
+dotnet test DopeGrid.Tests/DopeGrid.Tests.csproj
+```
+
+### Version Not Updating
+
+Ensure your tag follows the format `vX.Y.Z` or manually specify version in workflow dispatch.
+
+## Package URL
+
+Once published, your package will be available at:
+https://www.nuget.org/packages/DopeGrid
+
+## Updating Package Metadata
+
+To update package description, tags, or other metadata:
+
+1. Edit `dotnet/DopeGrid/DopeGrid.csproj`
+2. Update properties in the `<!-- NuGet Package Metadata -->` section
+3. Commit and push changes
+4. Create a new release with incremented version
+
+## Best Practices
+
+1. **Always test before releasing**: Run full test suite locally
+2. **Use descriptive release notes**: Help users understand what changed
+3. **Follow SemVer**: Make version numbers meaningful
+4. **Tag releases**: Use git tags for version tracking
+5. **Keep README updated**: Package includes README.md
+6. **Test major changes in pre-release**: Use `-beta` or `-alpha` suffixes

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -1,0 +1,62 @@
+name: Publish to NuGet
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g., 1.0.0)'
+        required: true
+        type: string
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '8.0.x'
+
+    - name: Extract version from tag
+      id: extract_version
+      run: |
+        if [ "${{ github.event_name }}" == "release" ]; then
+          VERSION="${{ github.event.release.tag_name }}"
+          # Remove 'v' prefix if present
+          VERSION="${VERSION#v}"
+        else
+          VERSION="${{ inputs.version }}"
+        fi
+        echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+        echo "Publishing version: $VERSION"
+
+    - name: Update version in csproj
+      run: |
+        sed -i "s/<Version>.*<\/Version>/<Version>${{ steps.extract_version.outputs.VERSION }}<\/Version>/" dotnet/DopeGrid/DopeGrid.csproj
+
+    - name: Restore dependencies
+      run: dotnet restore dotnet/DopeGrid/DopeGrid.csproj
+
+    - name: Build
+      run: dotnet build dotnet/DopeGrid/DopeGrid.csproj --configuration Release --no-restore
+
+    - name: Run tests
+      run: dotnet test dotnet/DopeGrid.Tests/DopeGrid.Tests.csproj --configuration Release --no-build --verbosity normal
+
+    - name: Pack
+      run: dotnet pack dotnet/DopeGrid/DopeGrid.csproj --configuration Release --no-build --output ./nupkg
+
+    - name: Publish to NuGet
+      run: dotnet nuget push ./nupkg/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: nuget-packages
+        path: ./nupkg/*.nupkg

--- a/dotnet/DopeGrid/DopeGrid.csproj
+++ b/dotnet/DopeGrid/DopeGrid.csproj
@@ -17,11 +17,29 @@
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <NoWarn>$(NoWarn);IDE0161</NoWarn>
         <RootNamespace>DopeGrid</RootNamespace>
+
+        <!-- NuGet Package Metadata -->
+        <PackageId>DopeGrid</PackageId>
+        <Version>1.0.0</Version>
+        <Authors>Full Metal Bagel</Authors>
+        <Company>Full Metal Bagel</Company>
+        <Product>Dope Grid</Product>
+        <Description>High-performance 2D grid library with efficient bit-array based shapes, inventory system, and transformation support. Supports rotation, flipping, and collision detection for game inventories and grid-based systems.</Description>
+        <PackageTags>grid;inventory;2d;game;gamedev;collections;bit-array;rotation;collision</PackageTags>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <PackageProjectUrl>https://github.com/Full-Metal-Bagel/dope-grid</PackageProjectUrl>
+        <RepositoryUrl>https://github.com/Full-Metal-Bagel/dope-grid.git</RepositoryUrl>
+        <RepositoryType>git</RepositoryType>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     </PropertyGroup>
 
     <ItemGroup>
         <Compile Include="../../Packages/com.fullmetalbagel.dope-grid/Runtime/**/*.cs" />
         <Link Include="../../.editorconfig" />
+        <None Include="../../README.md" Pack="true" PackagePath="/" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Summary
- Added GitHub Actions workflow to publish DopeGrid to NuGet.org
- Configured DopeGrid.csproj with NuGet package metadata
- Created comprehensive setup documentation

## Changes

### 1. NuGet Publishing Workflow (`.github/workflows/nuget-publish.yml`)

**Trigger Methods:**
- **Automatic**: Triggers on GitHub release creation (recommended for production)
- **Manual**: Workflow dispatch with version input (for testing/pre-releases)

**Workflow Steps:**
1. Extract version from git tag (e.g., `v1.0.0` → `1.0.0`) or manual input
2. Update version in DopeGrid.csproj dynamically
3. Restore dependencies and build in Release configuration
4. Run full test suite (aborts if tests fail)
5. Pack library and symbols (.nupkg + .snupkg)
6. Publish to NuGet.org using `NUGET_API_KEY` secret
7. Upload artifacts to GitHub for debugging

**Features:**
- `--skip-duplicate`: Won't fail if package version already exists
- Symbol package generation for debugging support
- Test gate ensures quality before publishing
- Artifact upload for post-mortem debugging

### 2. NuGet Package Metadata (`dotnet/DopeGrid/DopeGrid.csproj`)

Added comprehensive package configuration:

```xml
<PackageId>DopeGrid</PackageId>
<Version>1.0.0</Version>
<Authors>Full Metal Bagel</Authors>
<Description>High-performance 2D grid library with efficient bit-array based shapes, inventory system, and transformation support.</Description>
<PackageTags>grid;inventory;2d;game;gamedev;collections;bit-array;rotation;collision</PackageTags>
<PackageLicenseExpression>MIT</PackageLicenseExpression>
<PackageProjectUrl>https://github.com/Full-Metal-Bagel/dope-grid</PackageProjectUrl>
<RepositoryUrl>https://github.com/Full-Metal-Bagel/dope-grid.git</RepositoryUrl>
<PackageReadmeFile>README.md</PackageReadmeFile>
<IncludeSymbols>true</IncludeSymbols>
<SymbolPackageFormat>snupkg</SymbolPackageFormat>
```

**Includes in Package:**
- DopeGrid.dll (netstandard2.1)
- DopeGrid.pdb (debug symbols via .snupkg)
- README.md (project documentation)
- Dependencies: JetBrains.Annotations 2025.2.2

### 3. Setup Documentation (`.github/NUGET_SETUP.md`)

Comprehensive guide covering:
- **Prerequisites**: NuGet account, API key generation
- **GitHub Setup**: Adding `NUGET_API_KEY` secret
- **Publishing Methods**: Release creation vs manual dispatch
- **Version Management**: SemVer guidelines, pre-release versions
- **Workflow Details**: Step-by-step explanation
- **Testing**: Local package testing instructions
- **Troubleshooting**: Common issues and solutions
- **Best Practices**: Release guidelines

## Setup Required

Before the workflow can run, you need to:

1. **Create NuGet Account**: https://www.nuget.org (if not already created)
2. **Generate API Key**: https://www.nuget.org/account/apikeys
   - Name: "DopeGrid GitHub Actions"
   - Scope: Push
   - Package: DopeGrid (or glob pattern)
3. **Add GitHub Secret**:
   - Go to: https://github.com/Full-Metal-Bagel/dope-grid/settings/secrets/actions
   - Click "New repository secret"
   - Name: `NUGET_API_KEY`
   - Value: [Paste your NuGet API key]

See `.github/NUGET_SETUP.md` for detailed instructions.

## Usage Examples

### Publish via GitHub Release (Recommended)
```bash
# Create and push tag
git tag v1.0.0
git push origin v1.0.0

# Then create GitHub release from the tag
# Workflow automatically publishes to NuGet
```

### Publish via Manual Dispatch
1. Go to Actions → "Publish to NuGet"
2. Click "Run workflow"
3. Enter version (e.g., `1.0.0-beta.1`)
4. Click "Run workflow"

## Benefits

✅ **Automated Publishing**: No manual package building/uploading  
✅ **Quality Gate**: Tests must pass before publishing  
✅ **Version Control**: Git tags drive versioning  
✅ **Debug Support**: Symbol packages for source debugging  
✅ **Documentation**: README included in package  
✅ **Flexibility**: Auto-publish on release OR manual dispatch  
✅ **Idempotent**: Skip-duplicate prevents errors on re-runs

## Package Discovery

Once published, users can install via:
```bash
dotnet add package DopeGrid
```

Package will be available at: https://www.nuget.org/packages/DopeGrid

## Next Steps After Merge

1. Add `NUGET_API_KEY` secret to repository
2. Create first release (e.g., v1.0.0) to publish initial package
3. Update README with NuGet installation instructions
4. Consider adding NuGet badge to README: `[![NuGet](https://img.shields.io/nuget/v/DopeGrid.svg)](https://www.nuget.org/packages/DopeGrid/)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)