### PR TITLE
ci: add UPM release workflow using create-upm-release

### DIFF
--- a/.github/NUGET_SETUP.md
+++ b/.github/NUGET_SETUP.md
@@ -1,0 +1,154 @@
+# NuGet Publishing Setup
+
+This guide explains how to set up and use the NuGet publishing workflow for DopeGrid.
+
+## Prerequisites
+
+1. **NuGet Account**: Create an account at https://www.nuget.org
+2. **API Key**: Generate an API key from your NuGet account settings
+   - Go to https://www.nuget.org/account/apikeys
+   - Click "Create" and give it a name (e.g., "DopeGrid GitHub Actions")
+   - Set the key scope to "Push" and select package glob pattern or specific package
+   - Copy the generated API key (you'll only see it once!)
+
+## GitHub Setup
+
+### Add NuGet API Key as Secret
+
+1. Go to your GitHub repository: https://github.com/Full-Metal-Bagel/dope-grid
+2. Navigate to **Settings** → **Secrets and variables** → **Actions**
+3. Click **New repository secret**
+4. Name: `NUGET_API_KEY`
+5. Value: Paste your NuGet API key
+6. Click **Add secret**
+
+## Publishing Methods
+
+### Method 1: Automatic Publishing on Release (Recommended)
+
+This is the recommended approach for production releases.
+
+1. Create and push a git tag with version:
+   ```bash
+   git tag v1.0.0
+   git push origin v1.0.0
+   ```
+
+2. Go to GitHub Releases: https://github.com/Full-Metal-Bagel/dope-grid/releases
+3. Click **Draft a new release**
+4. Choose the tag you just created (v1.0.0)
+5. Fill in release title and description
+6. Click **Publish release**
+7. The workflow will automatically:
+   - Extract version from tag (removes 'v' prefix)
+   - Run tests
+   - Build and pack the NuGet package
+   - Publish to NuGet.org
+
+### Method 2: Manual Publishing via Workflow Dispatch
+
+Use this for testing or manual releases.
+
+1. Go to **Actions** tab: https://github.com/Full-Metal-Bagel/dope-grid/actions
+2. Select **Publish to NuGet** workflow
+3. Click **Run workflow**
+4. Enter version number (e.g., `1.0.0-beta`)
+5. Click **Run workflow**
+
+## Version Management
+
+### Semantic Versioning
+
+Follow [SemVer](https://semver.org/) for version numbers:
+- **MAJOR.MINOR.PATCH** (e.g., 1.0.0)
+- **MAJOR**: Breaking changes
+- **MINOR**: New features (backward compatible)
+- **PATCH**: Bug fixes (backward compatible)
+
+### Pre-release Versions
+
+For beta/alpha releases, append a suffix:
+- `1.0.0-alpha.1`
+- `1.0.0-beta.1`
+- `1.0.0-rc.1`
+
+## Workflow Details
+
+The workflow performs these steps:
+
+1. **Checkout**: Clones the repository
+2. **Setup .NET**: Installs .NET 8.0 SDK
+3. **Extract Version**: Gets version from tag or manual input
+4. **Update csproj**: Injects version into DopeGrid.csproj
+5. **Restore**: Restores NuGet dependencies
+6. **Build**: Builds in Release configuration
+7. **Test**: Runs all tests to ensure quality
+8. **Pack**: Creates .nupkg and .snupkg (symbols) files
+9. **Publish**: Pushes packages to NuGet.org
+10. **Upload Artifacts**: Saves packages as GitHub artifacts (for debugging)
+
+## Package Contents
+
+The published NuGet package includes:
+
+- **DopeGrid.dll**: Main library (netstandard2.1)
+- **DopeGrid.pdb**: Debug symbols (in separate .snupkg)
+- **README.md**: Project documentation
+- **Dependencies**: JetBrains.Annotations 2025.2.2
+
+## Testing the Package Locally
+
+Before publishing, you can test the package locally:
+
+```bash
+# Build and pack locally
+cd dotnet/DopeGrid
+dotnet pack --configuration Release --output ./local-nupkg
+
+# Test in another project
+cd /path/to/test/project
+dotnet add package DopeGrid --source /path/to/dope-grid/dotnet/DopeGrid/local-nupkg
+```
+
+## Troubleshooting
+
+### "Package already exists" Error
+
+If you see `409 Conflict - The package already exists`, either:
+- Increment the version number
+- The workflow uses `--skip-duplicate` to ignore this error
+
+### Tests Failing
+
+The workflow will abort if tests fail. Fix tests before publishing:
+```bash
+cd dotnet
+dotnet test DopeGrid.Tests/DopeGrid.Tests.csproj
+```
+
+### Version Not Updating
+
+Ensure your tag follows the format `vX.Y.Z` or manually specify version in workflow dispatch.
+
+## Package URL
+
+Once published, your package will be available at:
+https://www.nuget.org/packages/DopeGrid
+
+## Updating Package Metadata
+
+To update package description, tags, or other metadata:
+
+1. Edit `dotnet/DopeGrid/DopeGrid.csproj`
+2. Update properties in the `<!-- NuGet Package Metadata -->` section
+3. Commit and push changes
+4. Create a new release with incremented version
+
+## Best Practices
+
+1. **Always test before releasing**: Run full test suite locally
+2. **Use descriptive release notes**: Help users understand what changed
+3. **Follow SemVer**: Make version numbers meaningful
+4. **Tag releases**: Use git tags for version tracking
+5. **Keep README updated**: Package includes README.md
+6. **Test major changes in pre-release**: Use `-beta` or `-alpha` suffixes

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -1,0 +1,62 @@
+name: Publish to NuGet
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g., 1.0.0)'
+        required: true
+        type: string
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '8.0.x'
+
+    - name: Extract version from tag
+      id: extract_version
+      run: |
+        if [ "${{ github.event_name }}" == "release" ]; then
+          VERSION="${{ github.event.release.tag_name }}"
+          # Remove 'v' prefix if present
+          VERSION="${VERSION#v}"
+        else
+          VERSION="${{ inputs.version }}"
+        fi
+        echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+        echo "Publishing version: $VERSION"
+
+    - name: Update version in csproj
+      run: |
+        sed -i "s/<Version>.*<\/Version>/<Version>${{ steps.extract_version.outputs.VERSION }}<\/Version>/" dotnet/DopeGrid/DopeGrid.csproj
+
+    - name: Restore dependencies
+      run: dotnet restore dotnet/DopeGrid/DopeGrid.csproj
+
+    - name: Build
+      run: dotnet build dotnet/DopeGrid/DopeGrid.csproj --configuration Release --no-restore
+
+    - name: Run tests
+      run: dotnet test dotnet/DopeGrid.Tests/DopeGrid.Tests.csproj --configuration Release --no-build --verbosity normal
+
+    - name: Pack
+      run: dotnet pack dotnet/DopeGrid/DopeGrid.csproj --configuration Release --no-build --output ./nupkg
+
+    - name: Publish to NuGet
+      run: dotnet nuget push ./nupkg/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: nuget-packages
+        path: ./nupkg/*.nupkg

--- a/.github/workflows/release-upm.yml
+++ b/.github/workflows/release-upm.yml
@@ -1,0 +1,44 @@
+name: Publish UPM Packages
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'Packages/**/package.json'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  upm-release:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Dope Grid
+            package_path: Packages/com.fullmetalbagel.dope-grid
+            tag_prefix: v
+            unitypackage_name: com.fullmetalbagel.dope-grid
+          - name: Dope Inventory (uGUI)
+            package_path: Packages/com.fullmetalbagel.dope-inventory-ugui
+            tag_prefix: v
+            unitypackage_name: com.fullmetalbagel.dope-inventory-ugui
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Create Release for OpenUPM (${{ matrix.name }})
+        uses: quabug/create-upm-release@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          target: main
+          upm_tag_prefix: ${{ matrix.tag_prefix }}
+          upm_package_path: ${{ matrix.package_path }}
+          create_unitypackage: true
+          unitypackage_name: ${{ matrix.unitypackage_name }}
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,47 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- Unity packages live under `Packages/`:
+  - `com.fullmetalbagel.dope-grid/Runtime` — core grid/shape/board logic
+  - `com.fullmetalbagel.dope-inventory-ugui/Runtime` — uGUI inventory and input
+- Demo scene: `Assets/Scenes/Inventory(uGUI).unity`
+- Tests:
+  - Unity tests: `Assets/Tests/**`
+  - .NET mirror for faster CI: `dotnet/DopeGrid.Tests` (links Unity test sources)
+
+## Build, Test, and Development Commands
+- .NET restore/build/test (CI path):
+  - `dotnet restore dotnet/DopeGrid.Tests/DopeGrid.Tests.csproj`
+  - `dotnet build dotnet/DopeGrid.Tests/DopeGrid.Tests.csproj -c Release --no-restore`
+  - `dotnet test dotnet/DopeGrid.Tests/DopeGrid.Tests.csproj -c Release --no-build --collect:"XPlat Code Coverage"`
+- Solution-wide: `dotnet test dotnet/DopeGrid.sln`
+- Unity tests: Editor → Window → General → Test Runner → Run All
+- Run demo: open `Assets/Scenes/Inventory(uGUI).unity`
+
+## Coding Style & Naming Conventions
+- 4-space indent, LF, UTF-8; final newline; trim trailing whitespace (`.editorconfig`).
+- C# preferences: file-scoped namespaces; `using` outside namespace; braces required.
+- Fields: private/internal `_camelCase`; static `s_camelCase`; constants `PascalCase`.
+- Prefer keyword types (e.g., `int`), `var` only when obvious.
+- Analyzers on and warnings-as-errors; keep code clean and nullable-enabled.
+
+## Testing Guidelines
+- Framework: NUnit (`[TestFixture]`, `[Test]`).
+- Naming: place tests alongside feature area; filenames end with `*Tests.cs`.
+- Coverage: collected via `--collect:"XPlat Code Coverage"` (uploaded in CI).
+- Keep tests deterministic; avoid Unity-specific APIs in `.NET` tests.
+
+## Commit & Pull Request Guidelines
+- Use Conventional Commits: `feat:`, `fix:`, `refactor:`, etc. Example: `feat(grid): add IndexedGridBoard (#20)`.
+- Keep messages imperative and scoped; reference issues/PRs with `#123`.
+- PRs should include: clear description, screenshots for UI, test plan, and linked issues.
+- CI must pass (`.github/workflows/dotnet-test.yml`). For releases, NuGet publish is automated on tags.
+
+## Security & Configuration Tips
+- Target Unity 2022.3+; avoid unsafe operations in UI unless justified.
+- Core library permits `unsafe` for performance—validate bounds and pooling behavior.
+
+## Agent-Specific Notes
+- Follow `.editorconfig`; do not restructure packages arbitrarily.
+- If API changes, update tests and `README.md` paths accordingly.
+

--- a/Packages/com.fullmetalbagel.dope-grid/package.json
+++ b/Packages/com.fullmetalbagel.dope-grid/package.json
@@ -7,9 +7,5 @@
     "url": "https://github.com/Full-Metal-Bagel/dope-grid.git",
     "type": "git"
   },
-  "dependencies": {
-    "com.unity.collections": "2.1.4",
-    "com.unity.mathematics": "1.2.6"
-  },
   "hideInEditor": true
 }

--- a/Packages/com.fullmetalbagel.dope-inventory-ugui/Runtime/UI/DraggingItem.cs
+++ b/Packages/com.fullmetalbagel.dope-inventory-ugui/Runtime/UI/DraggingItem.cs
@@ -1,5 +1,4 @@
 using System;
-using Unity.Mathematics;
 using UnityEngine;
 
 namespace DopeGrid.Inventory;
@@ -12,7 +11,7 @@ public sealed class DraggingItem
     public RotationDegree Rotation { get; set; }
 
     public IUIInventory? TargetInventory { get; set; }
-    public int2 TargetPosition { get; set; } = default;
+    public Vector2Int TargetPosition { get; set; } = default;
     public int LastFrame { get; set; } = 0;
 
     public DraggingItem(Guid itemInstanceId, RectTransform view, RotationDegree rotation)

--- a/Packages/com.fullmetalbagel.dope-inventory-ugui/Runtime/UI/Extension.cs
+++ b/Packages/com.fullmetalbagel.dope-inventory-ugui/Runtime/UI/Extension.cs
@@ -1,5 +1,4 @@
 using JetBrains.Annotations;
-using Unity.Mathematics;
 using UnityEngine;
 using UnityEngine.EventSystems;
 
@@ -8,7 +7,7 @@ namespace DopeGrid.Inventory;
 public static class Extension
 {
     [Pure, MustUseReturnValue]
-    public static int2 GetGridPosition(this RectTransform transform, float2 cellSize, int shapeWidth, int shapeHeight, Vector2 worldPosition)
+    public static Vector2Int GetGridPosition(this RectTransform transform, Vector2 cellSize, int shapeWidth, int shapeHeight, Vector2 worldPosition)
     {
         // Convert from Canvas coordinates (center pivot) to InventoryView coordinates (top-left pivot)
         var localPosInInventory = transform.InverseTransformPoint(worldPosition);
@@ -28,7 +27,7 @@ public static class Extension
         var gridX = Mathf.RoundToInt(fromTopLeft.x / cellSize.x);
         var gridY = Mathf.RoundToInt(fromTopLeft.y / cellSize.y);
 
-        return new int2(gridX, gridY);
+        return new Vector2Int(gridX, gridY);
     }
 
     [Pure]

--- a/Packages/com.fullmetalbagel.dope-inventory-ugui/Runtime/UI/InventoryViewDebugOverlay.cs
+++ b/Packages/com.fullmetalbagel.dope-inventory-ugui/Runtime/UI/InventoryViewDebugOverlay.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using Unity.Mathematics;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -102,7 +101,7 @@ namespace DopeGrid.Inventory
             {
                 var item = inventory.GetItem(itemInstanceId);
                 var shape = item.Shape;
-                var origin = new int2(item.X, item.Y);
+                var origin = new Vector2Int(item.X, item.Y);
                 for (int y = 0; y < shape.Height; y++)
                 {
                     for (int x = 0; x < shape.Width; x++)
@@ -111,7 +110,7 @@ namespace DopeGrid.Inventory
                         var text = _itemTexts[index++];
                         var rt = (RectTransform)text.transform;
                         rt.sizeDelta = cellSize;
-                        var gridPos = new int2(origin.x + x, origin.y + y);
+                        var gridPos = new Vector2Int(origin.x + x, origin.y + y);
                         rt.anchoredPosition = new Vector2(gridPos.x * cellSize.x, -(gridPos.y * cellSize.y));
                         text.fontSize = fontSize;
                         text.text = BuildLabel(index, item.Id);
@@ -127,7 +126,7 @@ namespace DopeGrid.Inventory
             var cellSize = _view.CellSize;
             var width = inventory!.Width;
             var height = inventory.Height;
-            var needed = math.max(0, width * height);
+            var needed = Mathf.Max(0, width * height);
 
             EnsureTextPool(_emptyTexts, needed, _root!);
             DeactivateSurplus(_emptyTexts, needed);

--- a/Packages/com.fullmetalbagel.dope-inventory-ugui/Runtime/UI/InventoryViewDragPreviewController.cs
+++ b/Packages/com.fullmetalbagel.dope-inventory-ugui/Runtime/UI/InventoryViewDragPreviewController.cs
@@ -1,6 +1,5 @@
     using System;
     using System.Collections.Generic;
-    using Unity.Mathematics;
     using UnityEngine;
     using UnityEngine.Pool;
     using UnityEngine.UI;
@@ -135,7 +134,7 @@
             rt.pivot = new Vector2(0, 1);
         }
 
-        private Vector2 GridToAnchoredPosition(int2 gridPos)
+        private Vector2 GridToAnchoredPosition(Vector2Int gridPos)
         {
             // Top-left origin: X grows right, Y grows down
             return new Vector2(gridPos.x * _cellSize.x, -(gridPos.y * _cellSize.y));

--- a/Packages/com.fullmetalbagel.dope-inventory-ugui/Runtime/UI/InventoryViewSyncer.cs
+++ b/Packages/com.fullmetalbagel.dope-inventory-ugui/Runtime/UI/InventoryViewSyncer.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using Unity.Mathematics;
 using UnityEngine;
 using UnityEngine.Pool;
 using UnityEngine.UI;
@@ -59,7 +58,7 @@ internal sealed class InventoryViewSyncer : IDisposable
                 var preRotSize = rotation is RotationDegree.Clockwise90 or RotationDegree.Clockwise270
                     ? new Vector2(rotatedSize.y, rotatedSize.x)
                     : rotatedSize;
-                var pos = new int2(item.X, item.Y);
+                var pos = new Vector2Int(item.X, item.Y);
                 var anchoredPos = GridToAnchoredPosition(pos);
 
                 var rt = (RectTransform)image.transform;
@@ -123,7 +122,7 @@ internal sealed class InventoryViewSyncer : IDisposable
         rt.pivot = new Vector2(0, 1);
     }
 
-    private Vector2 GridToAnchoredPosition(int2 gridPos)
+    private Vector2 GridToAnchoredPosition(Vector2Int gridPos)
     {
         // Top-left origin: X grows right, Y grows down
         return new Vector2(gridPos.x * _cellSize.x, -(gridPos.y * _cellSize.y));

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -4,10 +4,7 @@
       "version": "file:com.fullmetalbagel.dope-grid",
       "depth": 0,
       "source": "embedded",
-      "dependencies": {
-        "com.unity.collections": "2.1.4",
-        "com.unity.mathematics": "1.2.6"
-      }
+      "dependencies": {}
     },
     "com.fullmetalbagel.dope-inventory-ugui": {
       "version": "file:com.fullmetalbagel.dope-inventory-ugui",
@@ -25,32 +22,11 @@
       "dependencies": {},
       "url": "https://package.openupm.com"
     },
-    "com.unity.burst": {
-      "version": "1.8.21",
-      "depth": 2,
-      "source": "registry",
-      "dependencies": {
-        "com.unity.mathematics": "1.2.1",
-        "com.unity.modules.jsonserialize": "1.0.0"
-      },
-      "url": "https://packages.unity.com"
-    },
     "com.unity.collab-proxy": {
       "version": "2.9.3",
       "depth": 0,
       "source": "registry",
       "dependencies": {},
-      "url": "https://packages.unity.com"
-    },
-    "com.unity.collections": {
-      "version": "2.1.4",
-      "depth": 1,
-      "source": "registry",
-      "dependencies": {
-        "com.unity.burst": "1.8.4",
-        "com.unity.nuget.mono-cecil": "1.11.4",
-        "com.unity.modules.unityanalytics": "1.0.0"
-      },
       "url": "https://packages.unity.com"
     },
     "com.unity.editorcoroutines": {
@@ -113,20 +89,6 @@
       "dependencies": {
         "com.unity.modules.uielements": "1.0.0"
       },
-      "url": "https://packages.unity.com"
-    },
-    "com.unity.mathematics": {
-      "version": "1.2.6",
-      "depth": 1,
-      "source": "registry",
-      "dependencies": {},
-      "url": "https://packages.unity.com"
-    },
-    "com.unity.nuget.mono-cecil": {
-      "version": "1.11.4",
-      "depth": 2,
-      "source": "registry",
-      "dependencies": {},
       "url": "https://packages.unity.com"
     },
     "com.unity.performance.profile-analyzer": {

--- a/dotnet/DopeGrid/DopeGrid.csproj
+++ b/dotnet/DopeGrid/DopeGrid.csproj
@@ -21,7 +21,7 @@
         <!-- NuGet Package Metadata -->
         <PackageId>DopeGrid</PackageId>
         <Version>1.0.0</Version>
-        <Authors>Full Metal Bagel</Authors>
+        <Authors>quabug</Authors>
         <Company>Full Metal Bagel</Company>
         <Product>Dope Grid</Product>
         <Description>High-performance 2D grid library with efficient bit-array based shapes, inventory system, and transformation support. Supports rotation, flipping, and collision detection for game inventories and grid-based systems.</Description>

--- a/dotnet/DopeGrid/DopeGrid.csproj
+++ b/dotnet/DopeGrid/DopeGrid.csproj
@@ -17,11 +17,29 @@
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <NoWarn>$(NoWarn);IDE0161</NoWarn>
         <RootNamespace>DopeGrid</RootNamespace>
+
+        <!-- NuGet Package Metadata -->
+        <PackageId>DopeGrid</PackageId>
+        <Version>1.0.0</Version>
+        <Authors>Full Metal Bagel</Authors>
+        <Company>Full Metal Bagel</Company>
+        <Product>Dope Grid</Product>
+        <Description>High-performance 2D grid library with efficient bit-array based shapes, inventory system, and transformation support. Supports rotation, flipping, and collision detection for game inventories and grid-based systems.</Description>
+        <PackageTags>grid;inventory;2d;game;gamedev;collections;bit-array;rotation;collision</PackageTags>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <PackageProjectUrl>https://github.com/Full-Metal-Bagel/dope-grid</PackageProjectUrl>
+        <RepositoryUrl>https://github.com/Full-Metal-Bagel/dope-grid.git</RepositoryUrl>
+        <RepositoryType>git</RepositoryType>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     </PropertyGroup>
 
     <ItemGroup>
         <Compile Include="../../Packages/com.fullmetalbagel.dope-grid/Runtime/**/*.cs" />
         <Link Include="../../.editorconfig" />
+        <None Include="../../README.md" Pack="true" PackagePath="/" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
- Adds .github/workflows/release-upm.yml to publish UPM packages using quabug/create-upm-release@v2.
- Publishes both packages:
  - Packages/com.fullmetalbagel.dope-grid -> tag com.fullmetalbagel.dope-grid@<version>
  - Packages/com.fullmetalbagel.dope-inventory-ugui -> tag com.fullmetalbagel.dope-inventory-ugui@<version>
- Attaches .unitypackage artifacts to releases.
- Triggers on push to main when package.json changes or manual dispatch.

Permissions: contents: write to allow release creation.