### PR TITLE
ci(workflows): use PAT for UPM releases and chain NuGet publish via workflow_run

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -1,11 +1,8 @@
 name: Publish to NuGet
 
 on:
-  # Chain after the UPM release workflow completes
-  workflow_run:
-    workflows: ["Publish UPM Packages"]
-    types: [completed]
-  # Allow manual runs for testing or ad-hoc publishing
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
       version:
@@ -15,8 +12,8 @@ on:
 
 jobs:
   publish:
-    # Run for manual dispatch, or when UPM workflow succeeds
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') }}
+    # Only run for release events with tag starting with 'dope-grid/'
+    if: ${{ github.event_name != 'release' || startsWith(github.event.release.tag_name, 'dope-grid/') }}
     runs-on: ubuntu-latest
 
     steps:
@@ -27,32 +24,23 @@ jobs:
       with:
         dotnet-version: '8.0.x'
 
-    - name: Determine version
-      id: version
-      uses: actions/github-script@v7
-      with:
-        script: |
-          const event = context.eventName;
-          if (event === 'workflow_dispatch') {
-            const v = core.getInput('version');
-            if (!v) core.setFailed('version input is required');
-            core.setOutput('tag', `dope-grid/v${v}`);
-            core.setOutput('version', v);
-            return;
-          }
-          // workflow_run path: find the latest dope-grid/* release
-          const {owner, repo} = context.repo;
-          const releases = await github.paginate(github.rest.repos.listReleases, {owner, repo, per_page: 100});
-          const rel = releases.find(r => r.tag_name && r.tag_name.startsWith('dope-grid/'));
-          if (!rel) core.setFailed('No dope-grid release found following UPM workflow run.');
-          const tag = rel.tag_name;
-          const version = tag.replace(/^dope-grid\//, '').replace(/^v/, '');
-          core.setOutput('tag', tag);
-          core.setOutput('version', version);
+    - name: Extract version from tag
+      id: extract_version
+      run: |
+        if [ "${{ github.event_name }}" = "release" ]; then
+          TAG="${{ github.event.release.tag_name }}"
+          # Expected format: dope-grid/vX.Y.Z
+          VERSION="${TAG#dope-grid/}"
+          VERSION="${VERSION#v}"
+        else
+          VERSION="${{ inputs.version }}"
+        fi
+        echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+        echo "Publishing version: $VERSION"
 
     - name: Update version in csproj
       run: |
-        sed -i "s/<Version>.*<\/Version>/<Version>${{ steps.version.outputs.version }}<\/Version>/" dotnet/DopeGrid/DopeGrid.csproj
+        sed -i "s/<Version>.*<\/Version>/<Version>${{ steps.extract_version.outputs.VERSION }}<\/Version>/" dotnet/DopeGrid/DopeGrid.csproj
 
     - name: Restore dependencies
       run: dotnet restore dotnet/DopeGrid/DopeGrid.csproj

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -1,8 +1,11 @@
 name: Publish to NuGet
 
 on:
-  release:
-    types: [published]
+  # Chain after the UPM release workflow completes
+  workflow_run:
+    workflows: ["Publish UPM Packages"]
+    types: [completed]
+  # Allow manual runs for testing or ad-hoc publishing
   workflow_dispatch:
     inputs:
       version:
@@ -12,8 +15,8 @@ on:
 
 jobs:
   publish:
-    # Only run for release events with tag starting with 'dope-grid/'
-    if: ${{ github.event_name != 'release' || startsWith(github.event.release.tag_name, 'dope-grid/') }}
+    # Run for manual dispatch, or when UPM workflow succeeds
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') }}
     runs-on: ubuntu-latest
 
     steps:
@@ -24,23 +27,32 @@ jobs:
       with:
         dotnet-version: '8.0.x'
 
-    - name: Extract version from tag
-      id: extract_version
-      run: |
-        if [ "${{ github.event_name }}" = "release" ]; then
-          TAG="${{ github.event.release.tag_name }}"
-          # Expected format: dope-grid/vX.Y.Z
-          VERSION="${TAG#dope-grid/}"
-          VERSION="${VERSION#v}"
-        else
-          VERSION="${{ inputs.version }}"
-        fi
-        echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
-        echo "Publishing version: $VERSION"
+    - name: Determine version
+      id: version
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const event = context.eventName;
+          if (event === 'workflow_dispatch') {
+            const v = core.getInput('version');
+            if (!v) core.setFailed('version input is required');
+            core.setOutput('tag', `dope-grid/v${v}`);
+            core.setOutput('version', v);
+            return;
+          }
+          // workflow_run path: find the latest dope-grid/* release
+          const {owner, repo} = context.repo;
+          const releases = await github.paginate(github.rest.repos.listReleases, {owner, repo, per_page: 100});
+          const rel = releases.find(r => r.tag_name && r.tag_name.startsWith('dope-grid/'));
+          if (!rel) core.setFailed('No dope-grid release found following UPM workflow run.');
+          const tag = rel.tag_name;
+          const version = tag.replace(/^dope-grid\//, '').replace(/^v/, '');
+          core.setOutput('tag', tag);
+          core.setOutput('version', version);
 
     - name: Update version in csproj
       run: |
-        sed -i "s/<Version>.*<\/Version>/<Version>${{ steps.extract_version.outputs.VERSION }}<\/Version>/" dotnet/DopeGrid/DopeGrid.csproj
+        sed -i "s/<Version>.*<\/Version>/<Version>${{ steps.version.outputs.version }}<\/Version>/" dotnet/DopeGrid/DopeGrid.csproj
 
     - name: Restore dependencies
       run: dotnet restore dotnet/DopeGrid/DopeGrid.csproj

--- a/.github/workflows/release-upm.yml
+++ b/.github/workflows/release-upm.yml
@@ -34,7 +34,9 @@ jobs:
       - name: Create Release for OpenUPM (${{ matrix.name }})
         uses: quabug/create-upm-release@v2
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Use a Personal Access Token so the created release triggers downstream workflows
+          # Create repo secret RELEASE_PAT with at least 'repo' scope
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
         with:
           target: main
           upm_tag_prefix: ${{ matrix.tag_prefix }}


### PR DESCRIPTION
- release-upm: use RELEASE_PAT to create releases that trigger downstream workflows\n- nuget-publish: trigger on workflow_run after 'Publish UPM Packages'; derive version from latest 'dope-grid/*' tag; keep manual dispatch path\n\nSecrets required:\n- RELEASE_PAT (repo scope)\n- NUGET_API_KEY (NuGet push)\n\nExpected behavior:\n- Push to Packages/**/package.json on main => UPM release creates 'dope-grid/vX.Y.Z' tag+release => NuGet workflow runs and publishes DopeGrid vX.Y.Z.\n\nNotes:\n- Only dope-grid tags trigger NuGet publish.\n- Manual run still supported via workflow_dispatch with version input.