### PR TITLE
feat(map): add Expand method to DualGridMap

### DIFF
--- a/Packages/com.fullmetalbagel.dope-grid/Runtime/Map/DualGridMap.cs
+++ b/Packages/com.fullmetalbagel.dope-grid/Runtime/Map/DualGridMap.cs
@@ -16,6 +16,16 @@ public sealed class DualGridMap<T> : IDisposable
     public int MaxX => _map.MaxX;
     public int MaxY => _map.MaxY;
 
+    public DualGridMap(int width, int height, int minX = 0, int minY = 0, T defaultValue = default)
+        :this(new MapBound(MinX: minX - 1, MinY: minY - 1, MaxX: minX + width + 1, MaxY: minY + height + 1), defaultValue)
+    {
+    }
+
+    public DualGridMap(MapBound bound, T defaultValue = default)
+    {
+        _map = new ExpandableMap<T>(bound, defaultValue);
+    }
+
     public bool IsOccupied(int x, int y) => _map.IsOccupied(x, y);
     public bool Contains(int x, int y) => _map.Contains(x, y);
 
@@ -25,14 +35,9 @@ public sealed class DualGridMap<T> : IDisposable
         set => _map[x, y] = value;
     }
 
-    public DualGridMap(int width, int height, int minX = 0, int minY = 0, T defaultValue = default)
-        :this(new MapBound(MinX: minX - 1, MinY: minY - 1, MaxX: minX + width + 1, MaxY: minY + height + 1), defaultValue)
+    public void Expand(MapBound newBound)
     {
-    }
-
-    public DualGridMap(MapBound bound, T defaultValue = default)
-    {
-        _map = new ExpandableMap<T>(bound, defaultValue);
+        _map.Expand(newBound);
     }
 
     public (T BL, T BR, T TL, T TR) GetVertexNeighbors(int x, int y)

--- a/Packages/com.fullmetalbagel.dope-grid/package.json
+++ b/Packages/com.fullmetalbagel.dope-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.fullmetalbagel.dope-grid",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "unity": "2022.3",
   "displayName": "Dope Grid",
   "repository": {


### PR DESCRIPTION
## Summary
- Add public `Expand` method to `DualGridMap` to expose the underlying `ExpandableMap`'s expansion capability
- Bump package version from 1.2.0 to 1.2.1

## Changes
- Added `DualGridMap.Expand(MapBound)` method that delegates to the internal `ExpandableMap`
- Updated package version in `package.json`

## Test plan
- [ ] Verify `DualGridMap.Expand` correctly expands the map bounds
- [ ] Existing tests continue to pass
- [ ] Version bump is reflected in package metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)